### PR TITLE
Enable batch norm and atom descriptor features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3.2.0
         with:
           activate-environment: cmpnn_env
           environment-file: environment.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run Pytest
+name: CI
 
 on:
   push:
@@ -21,13 +21,12 @@ jobs:
           environment-file: environment.yml
           auto-activate-base: false
 
-      - name: Make setup script executable
-        run: chmod +x setup_device_torch.sh
-
-      - name: Run setup script for CPU backend
+      - name: Install PyTorch dependencies (CPU)
         shell: bash -l {0}
-        run: echo "cpu" | ./setup_device_torch.sh
+        run: |
+          chmod +x setup_device_torch.sh
+          echo "cpu" | ./setup_device_torch.sh
 
-      - name: Run pytest
+      - name: Run tests
         shell: bash -l {0}
-        run: pytest tests/
+        run: pytest -q

--- a/cmpnn/data/molecule_data.py
+++ b/cmpnn/data/molecule_data.py
@@ -7,19 +7,21 @@ from torch.nn.utils.rnn import pad_sequence
 
 
 class MoleculeData(Data):
-    def __init__(self,
-                 f_atoms=None,
-                 f_bonds=None,
-                 a2b=None,
-                 b2a=None,
-                 a_scope=None,
-                 b_scope=None,
-                 global_features=None,
-                 y=None,
-                 bonds=None,
-                 smiles=None,
-                 b2revb=None,
-                 **kwargs):
+    def __init__(
+        self,
+        f_atoms=None,
+        f_bonds=None,
+        a2b=None,
+        b2a=None,
+        a_scope=None,
+        b_scope=None,
+        global_features=None,
+        y=None,
+        bonds=None,
+        smiles=None,
+        b2revb=None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.f_atoms = f_atoms
         self.f_bonds = f_bonds
@@ -34,11 +36,11 @@ class MoleculeData(Data):
         self.b2revb = b2revb
 
     def __inc__(self, key, value, *args, **kwargs):
-        if key in ['a_scope', 'b_scope']:
+        if key in ["a_scope", "b_scope"]:
             return 0  # prevent PyG from incrementing them
-        if key in ['a2b', 'bonds']:
+        if key in ["a2b", "bonds"]:
             return self.f_atoms.size(0)
-        if key in ['b2a']:
+        if key in ["b2a"]:
             return self.f_bonds.size(0)
         return super().__inc__(key, value, *args, **kwargs)
 
@@ -50,6 +52,7 @@ class MoleculeDataBatch(Batch):
     @staticmethod
     def from_data_list(data_list):
         import time
+
         t0 = time.perf_counter()
 
         batch = MoleculeDataBatch()
@@ -88,10 +91,9 @@ class MoleculeDataBatch(Batch):
                 for b in range(mol.f_bonds.size(0)):
                     b2a.append(n_atoms + mol.b2a[b])
                     b2revb.append(n_bonds + mol.b2revb[b])
-                    bonds.append([
-                        n_atoms + mol.b2a[b],
-                        n_atoms + mol.b2a[mol.b2revb[b]]
-                    ])
+                    bonds.append(
+                        [n_atoms + mol.b2a[b], n_atoms + mol.b2a[mol.b2revb[b]]]
+                    )
             else:
                 # Handle 1-atom molecule with dummy bond
                 b2a.append(0)
@@ -108,10 +110,14 @@ class MoleculeDataBatch(Batch):
 
         batch.max_num_bonds = max(1, max(len(x) for x in a2b))
         padded_a2b = [
-            x[:batch.max_num_bonds] + [0] * (batch.max_num_bonds - len(x)) for x in a2b
+            x[: batch.max_num_bonds] + [0] * (batch.max_num_bonds - len(x)) for x in a2b
         ]
 
-        bonds = torch.tensor(bonds, dtype=torch.long).T if bonds else torch.zeros((2, 0), dtype=torch.long)
+        bonds = (
+            torch.tensor(bonds, dtype=torch.long).T
+            if bonds
+            else torch.zeros((2, 0), dtype=torch.long)
+        )
 
         batch.f_atoms = torch.cat(f_atoms, dim=0)
         batch.f_bonds = torch.cat(f_bonds, dim=0)
@@ -122,10 +128,17 @@ class MoleculeDataBatch(Batch):
         batch.a_scope = a_scope
         batch.b_scope = b_scope
 
-        if hasattr(data_list[0], "global_features") and data_list[0].global_features is not None:
-            batch.global_features = torch.stack([mol.global_features for mol in data_list])
+        if (
+            hasattr(data_list[0], "global_features")
+            and data_list[0].global_features is not None
+        ):
+            batch.global_features = torch.stack(
+                [mol.global_features for mol in data_list]
+            )
         if hasattr(data_list[0], "y") and data_list[0].y is not None:
-            batch.y = torch.stack([mol.y if mol.y.dim() > 0 else mol.y.unsqueeze(0) for mol in data_list])
+            batch.y = torch.stack(
+                [mol.y if mol.y.dim() > 0 else mol.y.unsqueeze(0) for mol in data_list]
+            )
 
         t3 = time.perf_counter()
 
@@ -133,179 +146,17 @@ class MoleculeDataBatch(Batch):
         #     f"[from_data_list] Init: {t1 - t0:.4f}s | Loop: {t2 - t1:.4f}s | Finalize: {t3 - t2:.4f}s | Total: {t3 - t0:.4f}s")
         return batch
 
-    # @staticmethod
-    # def from_data_list(data_list):
-    #     batch = MoleculeDataBatch()
-    #     batch.smiles = [mol.smiles for mol in data_list]
-    #     batch.n_mols = len(batch.smiles)
-
-    #     # Atom/bond dimensions
-    #     atom_fdim = data_list[0].f_atoms.size(1)
-    #     bond_fdim = data_list[0].f_bonds.size(1)
-
-    #     # Totals
-    #     n_atoms_total = sum(mol.f_atoms.size(0) for mol in data_list)
-    #     n_bonds_total = sum(mol.f_bonds.size(0) for mol in data_list)
-
-    #     # Preallocate
-    #     f_atoms = torch.zeros((n_atoms_total + 1, atom_fdim))
-    #     f_bonds = torch.zeros((n_bonds_total + 1, bond_fdim))
-    #     b2a = torch.zeros(n_bonds_total + 1, dtype=torch.long)
-    #     b2revb = torch.zeros(n_bonds_total + 1, dtype=torch.long)
-    #     bonds = torch.zeros((n_bonds_total + 1, 2), dtype=torch.long)
-
-    #     global_features = []
-    #     targets = []
-
-    #     # For a2b: need to pad to max num bonds
-    #     max_num_bonds = max(len(bonds) for mol in data_list for bonds in mol.a2b)
-    #     a2b = torch.zeros((n_atoms_total + 1, max_num_bonds), dtype=torch.long)
-
-    #     a_scope = []
-    #     b_scope = []
-
-    #     atom_offset = 1
-    #     bond_offset = 1
-
-    #     for mol in data_list:
-    #         na = mol.f_atoms.size(0)
-    #         nb = mol.f_bonds.size(0)
-
-    #         f_atoms[atom_offset:atom_offset + na] = mol.f_atoms
-    #         f_bonds[bond_offset:bond_offset + nb] = mol.f_bonds
-
-    #         for a in range(na):
-    #             bond_ids = mol.a2b[a]
-    #             a2b[atom_offset + a, :len(bond_ids)] = torch.tensor(
-    #                 [bond_offset + b for b in bond_ids], dtype=torch.long
-    #             )
-
-    #         mol_b2a = torch.tensor(mol.b2a, dtype=torch.long)
-    #         mol_b2revb = mol.b2revb.clone().detach().to(dtype=torch.long)
-
-    #         b2revb[bond_offset:bond_offset + nb] = mol.b2revb.clone().detach() + bond_offset
-    #         b2revb[bond_offset:bond_offset + nb] = mol.b2revb.clone().detach() + bond_offset
-
-    #         for i in range(nb):
-    #             b2 = mol_b2a[i].item()
-    #             rb2 = mol_b2revb[i].item()
-    #             bonds[bond_offset + i, 0] = atom_offset + b2
-    #             bonds[bond_offset + i, 1] = atom_offset + mol_b2a[rb2].item()
-
-    #         a_scope.append((atom_offset, na))
-    #         b_scope.append((bond_offset, nb))
-
-    #         if hasattr(mol, "global_features") and mol.global_features is not None:
-    #             global_features.append(mol.global_features)
-
-    #         if hasattr(mol, "y") and mol.y is not None:
-    #             y = mol.y
-    #             if y.dim() == 0:
-    #                 y = y.unsqueeze(0)
-    #             targets.append(y)
-
-    #         atom_offset += na
-    #         bond_offset += nb
-
-    #     batch.f_atoms = f_atoms
-    #     batch.f_bonds = f_bonds
-    #     batch.a2b = a2b
-    #     batch.b2a = b2a
-    #     batch.b2revb = b2revb
-    #     batch.bonds = bonds.T  # shape [2, N] if required by model
-    #     batch.a_scope = a_scope
-    #     batch.b_scope = b_scope
-
-    #     if global_features:
-    #         batch.global_features = torch.stack(global_features)
-
-    #     if targets:
-    #         batch.y = torch.stack(targets)
-
-    #     return batch
-
-    # @staticmethod
-    # def from_data_list(data_list):
-    #     batch = MoleculeDataBatch()
-    #     batch.smiles = [mol.smiles for mol in data_list]
-    #     batch.n_mols = len(batch.smiles)
-
-    #     atom_fdim = data_list[0].f_atoms.size(1)
-    #     bond_fdim = data_list[0].f_bonds.size(1)
-
-    #     batch.n_atoms = 1
-    #     batch.n_bonds = 1
-    #     batch.a_scope = []
-    #     batch.b_scope = []
-
-    #     f_atoms = [torch.zeros(1, atom_fdim)]  # dummy row to align indexing
-    #     f_bonds = [torch.zeros(1, bond_fdim)]  # dummy row for bond features
-    #     a2b = [[]]
-    #     b2a = [0]
-    #     b2revb = [0]
-    #     bonds = [[0, 0]]
-
-    #     for data in data_list:
-    #         f_atoms.append(data.f_atoms)
-    #         # f_bonds.extend(data.f_bonds)
-    #         f_bonds.append(data.f_bonds)
-
-    #         for a in range(data.f_atoms.shape[0]):
-    #             a2b.append([b + batch.n_bonds for b in data.a2b[a]])
-
-    #         for b in range(data.f_bonds.shape[0]):
-    #             b2a_idx = batch.n_atoms + data.b2a[b]
-    #             rev_b_idx = data.b2revb[b]
-    #             b2a.append(b2a_idx)
-    #             b2revb.append(batch.n_bonds + rev_b_idx)
-    #             bonds.append([
-    #                 b2a_idx,
-    #                 batch.n_atoms + data.b2a[rev_b_idx]
-    #             ])
-    #         batch.a_scope.append((batch.n_atoms, data.f_atoms.shape[0]))
-    #         batch.b_scope.append((batch.n_bonds, data.f_bonds.shape[0]))
-
-    #         batch.n_atoms += data.f_atoms.shape[0]
-    #         batch.n_bonds += data.f_bonds.shape[0]
-    #     # batch.max_num_bonds = max(1, max(len(in_bonds) for in_bonds in a2b))
-    #     # # Pad a2b so that it has shape [n_atoms, max_num_bonds]
-    #     # padded_a2b = [
-    #     #     bonds[:batch.max_num_bonds] + [0] * (batch.max_num_bonds - len(bonds))
-    #     #     for bonds in a2b
-    #     # ]
-
-    #     ### NEW ###
-    #     a2b_tensors = [torch.tensor(in_bonds, dtype=torch.long) for in_bonds in a2b]
-    #     padded_a2b = pad_sequence(a2b_tensors, batch_first=True, padding_value=0)
-    #     batch.max_num_bonds = padded_a2b.shape[1]
-    #     ####
-
-    #     if len(bonds) == 0:
-    #         bonds = torch.zeros((0, 2), dtype=torch.long)
-    #     else:
-    #         bonds = torch.LongTensor(bonds)
-
-    #     # Convert everything to tensors
-    #     batch.f_atoms = torch.cat(f_atoms, dim=0)
-    #     # batch.f_bonds = torch.FloatTensor(f_bonds)
-    #     batch.f_bonds = torch.cat(f_bonds, dim=0)
-    #     batch.a2b = torch.LongTensor(padded_a2b)
-    #     batch.b2a = torch.LongTensor(b2a)
-    #     batch.b2revb = torch.LongTensor(b2revb)
-    #     batch.bonds = torch.LongTensor(bonds)
-    #     batch.a2a = None
-    #     batch.b2b = None
-
-    #     # Optional: global features or target aggregation
-    #     if hasattr(data_list[0], "global_features") and data_list[0].global_features is not None:
-    #         batch.global_features = torch.stack([mol.global_features for mol in data_list])
-    #     if hasattr(data_list[0], "y") and data_list[0].y is not None:
-    #         batch.y = torch.stack([mol.y if mol.y.dim() > 0 else mol.y.unsqueeze(0) for mol in data_list])
-
-    #     return batch
-
     def to(self, device):
-        for name in ['f_atoms', 'f_bonds', 'a2b', 'b2a', 'b2revb', 'bonds', 'global_features', 'y']:
+        for name in [
+            "f_atoms",
+            "f_bonds",
+            "a2b",
+            "b2a",
+            "b2revb",
+            "bonds",
+            "global_features",
+            "y",
+        ]:
             val = getattr(self, name, None)
             if torch.is_tensor(val):
                 setattr(self, name, val.to(device, non_blocking=True))
@@ -313,13 +164,17 @@ class MoleculeDataBatch(Batch):
 
 
 class MultiMoleculeDataBatch:
-    def __init__(self, components: List[MoleculeDataBatch], y: Optional[torch.Tensor] = None):
+    def __init__(
+        self, components: List[MoleculeDataBatch], y: Optional[torch.Tensor] = None
+    ):
         self.components = components
         self.n_components = len(components)
         self.n_samples = components[0].n_mols
 
         for comp in components:
-            assert comp.n_mols == self.n_samples, "All components must have the same number of samples"
+            assert (
+                comp.n_mols == self.n_samples
+            ), "All components must have the same number of samples"
 
         self.smiles = [comp.smiles for comp in components]
 
@@ -327,32 +182,44 @@ class MultiMoleculeDataBatch:
         if y is not None:
             self.y = y
         else:
-            y_vals = [getattr(comp, 'y', None) for comp in components]
+            y_vals = [getattr(comp, "y", None) for comp in components]
             if all(y is not None for y in y_vals):
                 base_y = y_vals[0]
-                assert all(torch.allclose(base_y, y_i) for y_i in y_vals[1:]), "Mismatched y values across components"
+                assert all(
+                    torch.allclose(base_y, y_i) for y_i in y_vals[1:]
+                ), "Mismatched y values across components"
                 self.y = base_y
             else:
                 self.y = None  # Acceptable case for inference
-                print("Warning: y values are missing or inconsistent across components.")
+                print(
+                    "Warning: y values are missing or inconsistent across components."
+                )
 
     @staticmethod
-    def from_data_list(data_list: List[List['MoleculeData']]) -> 'MultiMoleculeDataBatch':
+    def from_data_list(
+        data_list: List[List["MoleculeData"]],
+    ) -> "MultiMoleculeDataBatch":
         """
         Create a MultiMoleculeDataBatch from a list of molecule pairs (or tuples),
         e.g., [[mol1, mol2], [mol3, mol4], ...]
         """
         if not all(len(pair) == len(data_list[0]) for pair in data_list):
-            raise ValueError("All samples must have the same number of molecular components.")
+            raise ValueError(
+                "All samples must have the same number of molecular components."
+            )
 
         components = list(zip(*data_list))
-        batched_components = [MoleculeDataBatch.from_data_list(list(group)) for group in components]
+        batched_components = [
+            MoleculeDataBatch.from_data_list(list(group)) for group in components
+        ]
 
         # Optionally infer shared y from components
-        y_vals = [getattr(comp, 'y', None) for comp in batched_components]
+        y_vals = [getattr(comp, "y", None) for comp in batched_components]
         if all(y is not None for y in y_vals):
             base_y = y_vals[0]
-            assert all(torch.allclose(base_y, y_i) for y_i in y_vals[1:]), "Mismatched y values across components"
+            assert all(
+                torch.allclose(base_y, y_i) for y_i in y_vals[1:]
+            ), "Mismatched y values across components"
             return MultiMoleculeDataBatch(batched_components, y=base_y)
         else:
             return MultiMoleculeDataBatch(batched_components)
@@ -363,9 +230,11 @@ class MultiMoleculeDataBatch:
     def __len__(self) -> int:
         return self.n_samples
 
-    def to(self, device: Union[str, torch.device]) -> 'MultiMoleculeDataBatch':
-        return MultiMoleculeDataBatch([comp.to(device) for comp in self.components],
-                                      y=self.y.to(device) if self.y is not None else None)
+    def to(self, device: Union[str, torch.device]) -> "MultiMoleculeDataBatch":
+        return MultiMoleculeDataBatch(
+            [comp.to(device) for comp in self.components],
+            y=self.y.to(device) if self.y is not None else None,
+        )
 
     def __repr__(self):
         return f"MultiMoleculeDataBatch(n_samples={self.n_samples}, n_components={self.n_components})"

--- a/cmpnn/featurizer/molecule_dataset.py
+++ b/cmpnn/featurizer/molecule_dataset.py
@@ -18,12 +18,25 @@ class MoleculeDataset(InMemoryDataset):
     It provides methods to load, process, and transform molecular data into a format suitable for machine learning tasks.
     """
 
-    def __init__(self, csv_file: str, atom_featurizer, bond_featurizer, atom_messages: bool = False,
-                 transform=None, pre_transform=None, global_featurizer=None, use_cache: bool = True,
-                 weights_only: bool = False, smiles_col: str = "smiles", target_cols: Union[List[str], Dict[str, torch.dtype]] = None, label_encoder_path: Optional[str] = None,
-                 atom_descriptor_csv: str = None, rxn_col: str = "rxn_id", mol_type_col: str = "mol_type",
-                 **kwargs):
-
+    def __init__(
+        self,
+        csv_file: str,
+        atom_featurizer,
+        bond_featurizer,
+        atom_messages: bool = False,
+        transform=None,
+        pre_transform=None,
+        global_featurizer=None,
+        use_cache: bool = True,
+        weights_only: bool = False,
+        smiles_col: str = "smiles",
+        target_cols: Union[List[str], Dict[str, torch.dtype]] = None,
+        label_encoder_path: Optional[str] = None,
+        atom_descriptor_csv: str = None,
+        rxn_col: str = "rxn_id",
+        mol_type_col: str = "mol_type",
+        **kwargs,
+    ):
         self.csv_file = csv_file
         self.atom_featurizer = atom_featurizer
         self.bond_featurizer = bond_featurizer
@@ -34,19 +47,27 @@ class MoleculeDataset(InMemoryDataset):
         self.smiles_col = smiles_col
         self.target_cols = target_cols
         self.label_encoders = {}
-        self.atom_descriptor_df = pd.read_csv(atom_descriptor_csv) if atom_descriptor_csv else None
+        self.atom_descriptor_df = (
+            pd.read_csv(atom_descriptor_csv) if atom_descriptor_csv else None
+        )
         self.rxn_col = rxn_col
         self.mol_type_col = mol_type_col
         if self.atom_descriptor_df is not None:
-            self.descriptor_cols = [c for c in self.atom_descriptor_df.columns if c not in [self.rxn_col, self.mol_type_col]]
+            self.descriptor_cols = [
+                c
+                for c in self.atom_descriptor_df.columns
+                if c not in [self.rxn_col, self.mol_type_col]
+            ]
         else:
             self.descriptor_cols = []
-        super().__init__('.', transform, pre_transform)
+        super().__init__(".", transform, pre_transform)
 
         if self.use_cache and os.path.exists(self.processed_paths[0]):
             print(f"Loading cached data from {self.processed_paths[0]}")
-            self._data, self.slices = torch.load(self.processed_paths[0], weights_only=weights_only)
-            
+            self._data, self.slices = torch.load(
+                self.processed_paths[0], weights_only=weights_only
+            )
+
             # Load encoders if path provided
             if label_encoder_path and os.path.exists(label_encoder_path):
                 self.load_label_encoders(label_encoder_path)
@@ -62,14 +83,14 @@ class MoleculeDataset(InMemoryDataset):
 
     @property
     def processed_file_names(self):
-        return ['molecule_data.pt']
+        return ["molecule_data.pt"]
 
     def download(self):
         pass
 
     def process(self) -> List[MoleculeData]:
         df = pd.read_csv(self.csv_file)
-        
+
         if isinstance(self.target_cols, dict):
             target_map = self.target_cols
         elif isinstance(self.target_cols, list):
@@ -85,27 +106,38 @@ class MoleculeDataset(InMemoryDataset):
                 self.label_encoders[col] = le
 
         data_list = []
-        
+
         for idx, row in df.iterrows():
             smiles = row[self.smiles_col]
-            target = [torch.tensor(row[col], dtype=target_map[col]) for col in target_map]
+            target = [
+                torch.tensor(row[col], dtype=target_map[col]) for col in target_map
+            ]
             y = torch.stack(target) if len(target) > 1 else target[0]
 
             extra_features = None
-            if self.atom_descriptor_df is not None and self.rxn_col in row and self.mol_type_col in row:
+            if (
+                self.atom_descriptor_df is not None
+                and self.rxn_col in row
+                and self.mol_type_col in row
+            ):
                 rxn_id = row[self.rxn_col]
                 mol_type = row[self.mol_type_col]
-                mask = (self.atom_descriptor_df[self.rxn_col] == rxn_id) & (self.atom_descriptor_df[self.mol_type_col] == mol_type)
+                mask = (self.atom_descriptor_df[self.rxn_col] == rxn_id) & (
+                    self.atom_descriptor_df[self.mol_type_col] == mol_type
+                )
                 sub_df = self.atom_descriptor_df[mask]
                 if not sub_df.empty:
                     extra_features = sub_df[self.descriptor_cols].values
 
-            data = featurize_molecule(smiles=smiles, target=y,
-                                      atom_featurizer=self.atom_featurizer,
-                                      bond_featurizer=self.bond_featurizer,
-                                      global_featurizer=self.global_featurizer,
-                                      atom_messages=self.atom_messages,
-                                      extra_atom_features=extra_features)
+            data = featurize_molecule(
+                smiles=smiles,
+                target=y,
+                atom_featurizer=self.atom_featurizer,
+                bond_featurizer=self.bond_featurizer,
+                global_featurizer=self.global_featurizer,
+                atom_messages=self.atom_messages,
+                extra_atom_features=extra_features,
+            )
             data_list.append(data)
 
         data, slices = self.collate(data_list)
@@ -113,14 +145,12 @@ class MoleculeDataset(InMemoryDataset):
         return data_list
 
     def save_label_encoders(self, path):
-        with open(path, 'wb') as f:
+        with open(path, "wb") as f:
             pickle.dump(self.label_encoders, f)
 
     def load_label_encoders(self, path):
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             self.label_encoders = pickle.load(f)
-
-
 
 
 class MultiMoleculeDataset(Dataset):
@@ -128,10 +158,25 @@ class MultiMoleculeDataset(Dataset):
     MultiMoleculeDataset is a subclass of Dataset that is used to handle multiple molecular datasets.
     It provides methods to load, process, and transform molecular data into a format suitable for machine learning tasks.
     """
-    def __init__(self, csv_file: str, atom_featurizer, bond_featurizer, global_featurizer=None, cache_path: str = None,
-                 atom_messages: bool = False, use_cache: bool = True, weights_only: bool = False,
-                 smiles_cols: List[str] = ["smiles1", "smiles2"], target_cols: Union[List[str], Dict[str, torch.dtype]] = None, label_encoder_path: Optional[str] = None, atom_descriptor_csv: str = None, rxn_col: str = "rxn_id", mol_type_cols: Optional[List[str]] = None, mol_type_col: str = "mol_type"):
 
+    def __init__(
+        self,
+        csv_file: str,
+        atom_featurizer,
+        bond_featurizer,
+        global_featurizer=None,
+        cache_path: str = None,
+        atom_messages: bool = False,
+        use_cache: bool = True,
+        weights_only: bool = False,
+        smiles_cols: List[str] = ["smiles1", "smiles2"],
+        target_cols: Union[List[str], Dict[str, torch.dtype]] = None,
+        label_encoder_path: Optional[str] = None,
+        atom_descriptor_csv: str = None,
+        rxn_col: str = "rxn_id",
+        mol_type_cols: Optional[List[str]] = None,
+        mol_type_col: str = "mol_type",
+    ):
         self.atom_featurizer = atom_featurizer
         self.bond_featurizer = bond_featurizer
         self.global_featurizer = global_featurizer
@@ -141,12 +186,18 @@ class MultiMoleculeDataset(Dataset):
         self.smiles_cols = smiles_cols
         self.target_cols = target_cols
         self.label_encoders = {}
-        self.atom_descriptor_df = pd.read_csv(atom_descriptor_csv) if atom_descriptor_csv else None
+        self.atom_descriptor_df = (
+            pd.read_csv(atom_descriptor_csv) if atom_descriptor_csv else None
+        )
         self.rxn_col = rxn_col
         self.mol_type_cols = mol_type_cols or []
         self.desc_mol_type_col = mol_type_col
         if self.atom_descriptor_df is not None:
-            self.descriptor_cols = [c for c in self.atom_descriptor_df.columns if c not in [self.rxn_col, self.desc_mol_type_col]]
+            self.descriptor_cols = [
+                c
+                for c in self.atom_descriptor_df.columns
+                if c not in [self.rxn_col, self.desc_mol_type_col]
+            ]
         else:
             self.descriptor_cols = []
         if os.path.exists(self.cache_path) and self.use_cache:
@@ -179,8 +230,14 @@ class MultiMoleculeDataset(Dataset):
 
         for _, row in df.iterrows():
             smiles = [row[col] for col in self.smiles_cols]
-            mol_types = [row[col] for col in self.mol_type_cols] if self.mol_type_cols else [None] * len(smiles)
-            target = [torch.tensor(row[col], dtype=target_map[col]) for col in target_map]
+            mol_types = (
+                [row[col] for col in self.mol_type_cols]
+                if self.mol_type_cols
+                else [None] * len(smiles)
+            )
+            target = [
+                torch.tensor(row[col], dtype=target_map[col]) for col in target_map
+            ]
             y = torch.stack(target) if len(target) > 1 else target[0]
 
             mols_rdkit = [Chem.MolFromSmiles(smi) for smi in smiles]
@@ -194,13 +251,23 @@ class MultiMoleculeDataset(Dataset):
                 if self.atom_descriptor_df is not None and rxn_id is not None:
                     mask = self.atom_descriptor_df[self.rxn_col] == rxn_id
                     if mol_type is not None:
-                        mask &= self.atom_descriptor_df[self.desc_mol_type_col] == mol_type
+                        mask &= (
+                            self.atom_descriptor_df[self.desc_mol_type_col] == mol_type
+                        )
                     sub_df = self.atom_descriptor_df[mask]
                     if not sub_df.empty:
                         extra_features = sub_df[self.descriptor_cols].values
-                data.append(featurize_molecule(smi, y, self.atom_featurizer, self.bond_featurizer,
-                                              self.global_featurizer, self.atom_messages,
-                                              extra_atom_features=extra_features))
+                data.append(
+                    featurize_molecule(
+                        smi,
+                        y,
+                        self.atom_featurizer,
+                        self.bond_featurizer,
+                        self.global_featurizer,
+                        self.atom_messages,
+                        extra_atom_features=extra_features,
+                    )
+                )
             data_list.append(data)
 
         return data_list
@@ -212,9 +279,9 @@ class MultiMoleculeDataset(Dataset):
         return self.data[idx]
 
     def save_label_encoders(self, path):
-        with open(path, 'wb') as f:
+        with open(path, "wb") as f:
             pickle.dump(self.label_encoders, f)
 
     def load_label_encoders(self, path):
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             self.label_encoders = pickle.load(f)

--- a/cmpnn/featurizer/molecule_dataset.py
+++ b/cmpnn/featurizer/molecule_dataset.py
@@ -21,6 +21,7 @@ class MoleculeDataset(InMemoryDataset):
     def __init__(self, csv_file: str, atom_featurizer, bond_featurizer, atom_messages: bool = False,
                  transform=None, pre_transform=None, global_featurizer=None, use_cache: bool = True,
                  weights_only: bool = False, smiles_col: str = "smiles", target_cols: Union[List[str], Dict[str, torch.dtype]] = None, label_encoder_path: Optional[str] = None,
+                 atom_descriptor_csv: str = None, rxn_col: str = "rxn_id", mol_type_col: str = "mol_type",
                  **kwargs):
 
         self.csv_file = csv_file
@@ -33,6 +34,13 @@ class MoleculeDataset(InMemoryDataset):
         self.smiles_col = smiles_col
         self.target_cols = target_cols
         self.label_encoders = {}
+        self.atom_descriptor_df = pd.read_csv(atom_descriptor_csv) if atom_descriptor_csv else None
+        self.rxn_col = rxn_col
+        self.mol_type_col = mol_type_col
+        if self.atom_descriptor_df is not None:
+            self.descriptor_cols = [c for c in self.atom_descriptor_df.columns if c not in [self.rxn_col, self.mol_type_col]]
+        else:
+            self.descriptor_cols = []
         super().__init__('.', transform, pre_transform)
 
         if self.use_cache and os.path.exists(self.processed_paths[0]):
@@ -82,11 +90,22 @@ class MoleculeDataset(InMemoryDataset):
             smiles = row[self.smiles_col]
             target = [torch.tensor(row[col], dtype=target_map[col]) for col in target_map]
             y = torch.stack(target) if len(target) > 1 else target[0]
+
+            extra_features = None
+            if self.atom_descriptor_df is not None and self.rxn_col in row and self.mol_type_col in row:
+                rxn_id = row[self.rxn_col]
+                mol_type = row[self.mol_type_col]
+                mask = (self.atom_descriptor_df[self.rxn_col] == rxn_id) & (self.atom_descriptor_df[self.mol_type_col] == mol_type)
+                sub_df = self.atom_descriptor_df[mask]
+                if not sub_df.empty:
+                    extra_features = sub_df[self.descriptor_cols].values
+
             data = featurize_molecule(smiles=smiles, target=y,
                                       atom_featurizer=self.atom_featurizer,
                                       bond_featurizer=self.bond_featurizer,
                                       global_featurizer=self.global_featurizer,
-                                      atom_messages=self.atom_messages)
+                                      atom_messages=self.atom_messages,
+                                      extra_atom_features=extra_features)
             data_list.append(data)
 
         data, slices = self.collate(data_list)
@@ -111,7 +130,7 @@ class MultiMoleculeDataset(Dataset):
     """
     def __init__(self, csv_file: str, atom_featurizer, bond_featurizer, global_featurizer=None, cache_path: str = None,
                  atom_messages: bool = False, use_cache: bool = True, weights_only: bool = False,
-                 smiles_cols: List[str] = ["smiles1", "smiles2"], target_cols: Union[List[str], Dict[str, torch.dtype]] = None, label_encoder_path: Optional[str] = None):
+                 smiles_cols: List[str] = ["smiles1", "smiles2"], target_cols: Union[List[str], Dict[str, torch.dtype]] = None, label_encoder_path: Optional[str] = None, atom_descriptor_csv: str = None, rxn_col: str = "rxn_id", mol_type_cols: Optional[List[str]] = None, mol_type_col: str = "mol_type"):
 
         self.atom_featurizer = atom_featurizer
         self.bond_featurizer = bond_featurizer
@@ -122,6 +141,14 @@ class MultiMoleculeDataset(Dataset):
         self.smiles_cols = smiles_cols
         self.target_cols = target_cols
         self.label_encoders = {}
+        self.atom_descriptor_df = pd.read_csv(atom_descriptor_csv) if atom_descriptor_csv else None
+        self.rxn_col = rxn_col
+        self.mol_type_cols = mol_type_cols or []
+        self.desc_mol_type_col = mol_type_col
+        if self.atom_descriptor_df is not None:
+            self.descriptor_cols = [c for c in self.atom_descriptor_df.columns if c not in [self.rxn_col, self.desc_mol_type_col]]
+        else:
+            self.descriptor_cols = []
         if os.path.exists(self.cache_path) and self.use_cache:
             print(f"Loading cached dataset from {self.cache_path}")
             self.data = torch.load(self.cache_path, weights_only=weights_only)
@@ -152,15 +179,28 @@ class MultiMoleculeDataset(Dataset):
 
         for _, row in df.iterrows():
             smiles = [row[col] for col in self.smiles_cols]
+            mol_types = [row[col] for col in self.mol_type_cols] if self.mol_type_cols else [None] * len(smiles)
             target = [torch.tensor(row[col], dtype=target_map[col]) for col in target_map]
             y = torch.stack(target) if len(target) > 1 else target[0]
 
-            mols = [Chem.MolFromSmiles(smi) for smi in smiles]
-            if any(mol is None for mol in mols):
+            mols_rdkit = [Chem.MolFromSmiles(smi) for smi in smiles]
+            if any(mol is None for mol in mols_rdkit):
                 continue
 
-            data = [featurize_molecule(smi, y, self.atom_featurizer, self.bond_featurizer,
-                                       self.global_featurizer, self.atom_messages) for smi in smiles]
+            rxn_id = row[self.rxn_col] if self.rxn_col in row else None
+            data = []
+            for smi, mol_type in zip(smiles, mol_types):
+                extra_features = None
+                if self.atom_descriptor_df is not None and rxn_id is not None:
+                    mask = self.atom_descriptor_df[self.rxn_col] == rxn_id
+                    if mol_type is not None:
+                        mask &= self.atom_descriptor_df[self.desc_mol_type_col] == mol_type
+                    sub_df = self.atom_descriptor_df[mask]
+                    if not sub_df.empty:
+                        extra_features = sub_df[self.descriptor_cols].values
+                data.append(featurize_molecule(smi, y, self.atom_featurizer, self.bond_featurizer,
+                                              self.global_featurizer, self.atom_messages,
+                                              extra_atom_features=extra_features))
             data_list.append(data)
 
         return data_list

--- a/cmpnn/featurizer/utils.py
+++ b/cmpnn/featurizer/utils.py
@@ -29,6 +29,14 @@ def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, gl
         f_atoms.append(atom_featurizer(atom))
     f_atoms = [f_atoms[i] for i in range(n_atoms)]
 
+    if extra_atom_features is not None:
+        extra_atom_features = torch.tensor(extra_atom_features, dtype=torch.float32)
+        if extra_atom_features.dim() == 1:
+            extra_atom_features = extra_atom_features.unsqueeze(0)
+        if extra_atom_features.size(0) != n_atoms:
+            raise ValueError("Mismatch between number of atoms and extra descriptors")
+        f_atoms = [torch.cat([f_atoms[i], extra_atom_features[i]], dim=0) for i in range(n_atoms)]
+
     for _ in range(n_atoms):
         a2b.append([])
 
@@ -62,14 +70,6 @@ def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, gl
 
     # Convert features to tensors
     f_atoms = torch.stack(f_atoms)
-
-    if extra_atom_features is not None:
-        extra_atom_features = torch.tensor(extra_atom_features, dtype=torch.float32)
-        if extra_atom_features.dim() == 1:
-            extra_atom_features = extra_atom_features.unsqueeze(0)
-        if extra_atom_features.size(0) != f_atoms.size(0):
-            raise ValueError("Mismatch between number of atoms and extra descriptors")
-        f_atoms = torch.cat([f_atoms, extra_atom_features], dim=1)
 
     if len(f_bonds) == 0:
         if atom_messages:

--- a/cmpnn/featurizer/utils.py
+++ b/cmpnn/featurizer/utils.py
@@ -6,8 +6,16 @@ from cmpnn.data.molecule_data import MoleculeData
 from typing import List, Callable, Optional
 import pickle
 
-def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, global_featurizer=None,
-                       atom_messages=False, extra_atom_features=None):
+
+def featurize_molecule(
+    smiles: str,
+    target,
+    atom_featurizer,
+    bond_featurizer,
+    global_featurizer=None,
+    atom_messages=False,
+    extra_atom_features=None,
+):
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         raise ValueError(f"Invalid SMILES string: {smiles}")
@@ -35,7 +43,10 @@ def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, gl
             extra_atom_features = extra_atom_features.unsqueeze(0)
         if extra_atom_features.size(0) != n_atoms:
             raise ValueError("Mismatch between number of atoms and extra descriptors")
-        f_atoms = [torch.cat([f_atoms[i], extra_atom_features[i]], dim=0) for i in range(n_atoms)]
+        f_atoms = [
+            torch.cat([f_atoms[i], extra_atom_features[i]], dim=0)
+            for i in range(n_atoms)
+        ]
 
     for _ in range(n_atoms):
         a2b.append([])
@@ -76,9 +87,8 @@ def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, gl
             f_bonds.append(bond_featurizer(None))
         else:
             f_bonds.append(torch.cat([f_atoms[0], bond_featurizer(None)]))
-            
-    f_bonds = torch.stack(f_bonds)
 
+    f_bonds = torch.stack(f_bonds)
 
     a2b = a2b
     b2a = b2a
@@ -114,6 +124,6 @@ def infer_dtype(series: pd.Series) -> torch.dtype:
     elif pd.api.types.is_bool_dtype(series):
         return torch.float32
     elif pd.api.types.is_object_dtype(series):
-        return torch.long 
+        return torch.long
     else:
         raise ValueError(f"Unsupported target type: {series.dtype}")

--- a/cmpnn/featurizer/utils.py
+++ b/cmpnn/featurizer/utils.py
@@ -7,7 +7,7 @@ from typing import List, Callable, Optional
 import pickle
 
 def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, global_featurizer=None,
-                       atom_messages=False):
+                       atom_messages=False, extra_atom_features=None):
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         raise ValueError(f"Invalid SMILES string: {smiles}")
@@ -62,6 +62,14 @@ def featurize_molecule(smiles: str, target, atom_featurizer, bond_featurizer, gl
 
     # Convert features to tensors
     f_atoms = torch.stack(f_atoms)
+
+    if extra_atom_features is not None:
+        extra_atom_features = torch.tensor(extra_atom_features, dtype=torch.float32)
+        if extra_atom_features.dim() == 1:
+            extra_atom_features = extra_atom_features.unsqueeze(0)
+        if extra_atom_features.size(0) != f_atoms.size(0):
+            raise ValueError("Mismatch between number of atoms and extra descriptors")
+        f_atoms = torch.cat([f_atoms, extra_atom_features], dim=1)
 
     if len(f_bonds) == 0:
         if atom_messages:

--- a/cmpnn/models/cmpnn.py
+++ b/cmpnn/models/cmpnn.py
@@ -11,15 +11,33 @@ class CMPNNEncoder(MessagePassing):
     It uses a message passing mechanism to learn representations of molecular graphs.
     """
 
-    def __init__(self, atom_fdim: int, bond_fdim: int, atom_messages: bool, depth: int = 3,
-                 dropout: float = 0.1, hidden_dim: int = 128, use_batch_norm: bool = True,
-                 activation: str = 'relu', bias: bool = True, booster: str = 'sum', comm_mode: str = 'add'):
-        """
-        """
-        assert comm_mode in ['add', 'mlp', 'gru',
-                             'ip'], f"Invalid comm_mode: {comm_mode}. Must be one of ['add', 'mlp', 'gru', 'ip']"
-        assert booster in ['sum', 'sum_max', 'attention',
-                           'mean'], f"Invalid booster: {booster}. Must be one of ['sum', 'sum_max', 'attention', 'mean']"
+    def __init__(
+        self,
+        atom_fdim: int,
+        bond_fdim: int,
+        atom_messages: bool,
+        depth: int = 3,
+        dropout: float = 0.1,
+        hidden_dim: int = 128,
+        use_batch_norm: bool = True,
+        activation: str = "relu",
+        bias: bool = True,
+        booster: str = "sum",
+        comm_mode: str = "add",
+    ):
+        """ """
+        assert comm_mode in [
+            "add",
+            "mlp",
+            "gru",
+            "ip",
+        ], f"Invalid comm_mode: {comm_mode}. Must be one of ['add', 'mlp', 'gru', 'ip']"
+        assert booster in [
+            "sum",
+            "sum_max",
+            "attention",
+            "mean",
+        ], f"Invalid booster: {booster}. Must be one of ['sum', 'sum_max', 'attention', 'mean']"
 
         self.booster = booster
         self.comm_mode = comm_mode
@@ -47,17 +65,20 @@ class CMPNNEncoder(MessagePassing):
         self.gru = BatchGRU(hidden_dim)
 
         # Communication Mode
-        if comm_mode == 'mlp':
+        if comm_mode == "mlp":
             self.atom_mlp = nn.Sequential(
-                nn.Linear(hidden_dim * 2, hidden_dim),
-                get_activation_fn(activation)
+                nn.Linear(hidden_dim * 2, hidden_dim), get_activation_fn(activation)
             )
-        elif comm_mode == 'gru':
+        elif comm_mode == "gru":
             self.atom_gru = nn.GRUCell(hidden_dim, hidden_dim)
 
         # Create stack of message passing layers
-        self.W_h = nn.ModuleList([nn.Linear(hidden_dim, self.hidden_dim, bias=bias)
-                                  for _ in range(depth - 1)])
+        self.W_h = nn.ModuleList(
+            [
+                nn.Linear(hidden_dim, self.hidden_dim, bias=bias)
+                for _ in range(depth - 1)
+            ]
+        )
 
     def initialize(self, f_atoms: torch.Tensor, f_bonds: torch.Tensor):
         """
@@ -73,21 +94,29 @@ class CMPNNEncoder(MessagePassing):
     def message(self, message_bond: torch.Tensor, a2b: torch.Tensor) -> torch.Tensor:
         agg = index_select_ND(message_bond, a2b)  # [num_atoms, max_bonds, hidden]
 
-        if self.booster == 'sum':
+        if self.booster == "sum":
             return agg.sum(dim=1)
-        elif self.booster == 'mean':
+        elif self.booster == "mean":
             return agg.mean(dim=1)
-        elif self.booster == 'sum_max':
+        elif self.booster == "sum_max":
             return agg.sum(dim=1) * agg.max(dim=1)[0]
-        elif self.booster == 'attention':
-            scores = torch.softmax(torch.sum(agg, dim=2), dim=1).unsqueeze(-1)  # (n_atoms, max_bonds, 1)
+        elif self.booster == "attention":
+            scores = torch.softmax(torch.sum(agg, dim=2), dim=1).unsqueeze(
+                -1
+            )  # (n_atoms, max_bonds, 1)
             return torch.sum(agg * scores, dim=1)  # Weighted sum
         else:
             raise ValueError(f"Unsupported booster: {self.booster}")
 
-    def update(self, message_atom: torch.Tensor, message_bond: torch.Tensor,
-               input_bond: torch.Tensor, b2a: torch.Tensor, b2revb: torch.Tensor,
-               depth_index: int) -> torch.Tensor:
+    def update(
+        self,
+        message_atom: torch.Tensor,
+        message_bond: torch.Tensor,
+        input_bond: torch.Tensor,
+        b2a: torch.Tensor,
+        b2revb: torch.Tensor,
+        depth_index: int,
+    ) -> torch.Tensor:
         """
         Update bond messages based on the current atom messages.
         """
@@ -98,12 +127,12 @@ class CMPNNEncoder(MessagePassing):
         return updated
 
     def communicate(self, message_atom: torch.Tensor, agg: torch.Tensor):
-        if self.comm_mode == 'mlp':
+        if self.comm_mode == "mlp":
             fused = torch.cat([message_atom, agg], dim=1)
             return self.atom_mlp(fused)
-        elif self.comm_mode == 'gru':
+        elif self.comm_mode == "gru":
             return self.atom_gru(agg, message_atom)
-        elif self.comm_mode == 'ip':
+        elif self.comm_mode == "ip":
             return message_atom * agg
         else:
             return message_atom + agg
@@ -116,24 +145,36 @@ class CMPNNEncoder(MessagePassing):
         updated = self.lr(combined)
         return self.gru(updated, a_scope)
 
-    def forward(self, f_atoms: torch.Tensor, f_bonds: torch.Tensor,
-                a2b: torch.Tensor, b2a: torch.Tensor, b2revb: torch.Tensor,
-                a_scope: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        f_atoms: torch.Tensor,
+        f_bonds: torch.Tensor,
+        a2b: torch.Tensor,
+        b2a: torch.Tensor,
+        b2revb: torch.Tensor,
+        a_scope: torch.Tensor,
+    ) -> torch.Tensor:
         """
         Forward pass through the encoder.
         """
         # Initialize atom and bond messages
-        input_atom, message_atom, input_bond, message_bond = self.initialize(f_atoms, f_bonds)
+        input_atom, message_atom, input_bond, message_bond = self.initialize(
+            f_atoms, f_bonds
+        )
 
         # Message passing
         for depth in range(self.depth - 1):
             agg = self.message(message_bond, a2b)
             message_atom = self.communicate(message_atom, agg)
-            message_bond = self.update(message_atom, message_bond, input_bond, b2a, b2revb, depth)
+            message_bond = self.update(
+                message_atom, message_bond, input_bond, b2a, b2revb, depth
+            )
 
         # Final Communication
         agg_message = self.message(message_bond, a2b)
-        agg_message = self.final_communicate(agg_message, message_atom, input_atom, a_scope)
+        agg_message = self.final_communicate(
+            agg_message, message_atom, input_atom, a_scope
+        )
 
         atom_hiddens = self.act_func(self.W_o(agg_message))
         atom_hiddens = self.bn(atom_hiddens)

--- a/cmpnn/models/cmpnn.py
+++ b/cmpnn/models/cmpnn.py
@@ -34,6 +34,9 @@ class CMPNNEncoder(MessagePassing):
         self.dropout_layer = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
         self.act_func = get_activation_fn(activation)
 
+        # Batch normalization (optional)
+        self.bn = nn.BatchNorm1d(hidden_dim) if use_batch_norm else nn.Identity()
+
         # Input layers
         self.W_i_atom = nn.Linear(atom_fdim, hidden_dim, bias=bias)
         self.W_i_bond = nn.Linear(bond_fdim, hidden_dim, bias=bias)
@@ -133,6 +136,7 @@ class CMPNNEncoder(MessagePassing):
         agg_message = self.final_communicate(agg_message, message_atom, input_atom, a_scope)
 
         atom_hiddens = self.act_func(self.W_o(agg_message))
+        atom_hiddens = self.bn(atom_hiddens)
         atom_hiddens = self.dropout_layer(atom_hiddens)
 
         return atom_hiddens

--- a/cmpnn/models/lightning.py
+++ b/cmpnn/models/lightning.py
@@ -16,35 +16,36 @@ class CMPNNLightningModule(pl.LightningModule):
     A PyTorch Lightning module for the CMPNN model.
     """
 
-    def __init__(self,
-                 atom_fdim: int = 133,
-                 bond_fdim: int = 14,
-                 global_fdim: int = 0,
-                 atom_messages: bool = True,
-                 depth: int = 3,
-                 output_size: int = 1,
-                 hidden_dim: int = 128,
-                 dropout: float = 0.1,
-                 activation: str = 'relu',
-                 bias: bool = False,
-                 booster: str = 'sum',
-                 comm_mode: str = 'add',
-                 prediction_type: str = 'regression',
-                 aggregator: str = 'mean',
-                 use_batch_norm: bool = False,
-                 ffn_config: dict = None,
-                 optimizer_class: type = torch.optim.Adam,
-                 optimizer_params: dict = None,
-                 learning_rate: float = 1e-3,
-                 metrics: dict = None,
-                 plot_lr: bool = False):
-
+    def __init__(
+        self,
+        atom_fdim: int = 133,
+        bond_fdim: int = 14,
+        global_fdim: int = 0,
+        atom_messages: bool = True,
+        depth: int = 3,
+        output_size: int = 1,
+        hidden_dim: int = 128,
+        dropout: float = 0.1,
+        activation: str = "relu",
+        bias: bool = False,
+        booster: str = "sum",
+        comm_mode: str = "add",
+        prediction_type: str = "regression",
+        aggregator: str = "mean",
+        use_batch_norm: bool = False,
+        ffn_config: dict = None,
+        optimizer_class: type = torch.optim.Adam,
+        optimizer_params: dict = None,
+        learning_rate: float = 1e-3,
+        metrics: dict = None,
+        plot_lr: bool = False,
+    ):
         super().__init__()
         self.save_hyperparameters()
         self.output_size = output_size
         self.prediction_type = prediction_type
         self.plot_lr = plot_lr
-        if self.prediction_type == 'classification':
+        if self.prediction_type == "classification":
             self.sigmoid = nn.Sigmoid()
 
         # Create the model
@@ -63,11 +64,11 @@ class CMPNNLightningModule(pl.LightningModule):
         )
 
         # Set the aggregator
-        if aggregator == 'mean':
+        if aggregator == "mean":
             self.aggregator = MeanAggregator()
-        elif aggregator == 'sum':
+        elif aggregator == "sum":
             self.aggregator = SumAggregator()
-        elif aggregator == 'norm_mean':
+        elif aggregator == "norm_mean":
             self.aggregator = NormMeanAggregator()
         else:
             raise ValueError(f"Unknown aggregator: {aggregator}")
@@ -77,13 +78,14 @@ class CMPNNLightningModule(pl.LightningModule):
         # Determine the input dimensions for the FFN
         ffn_input_dim = hidden_dim + global_fdim
         ffn_config = ffn_config if ffn_config else {}
-        self.ffn = MLP(input_dim=ffn_input_dim,
-                       output_dim=output_size,
-                       hidden_dim=ffn_config.get('hidden_dim', hidden_dim),
-                       n_layers=ffn_config.get('n_layers', 1),
-                       dropout=ffn_config.get('dropout', dropout),
-                       activation=ffn_config.get('activation', activation)
-                       )
+        self.ffn = MLP(
+            input_dim=ffn_input_dim,
+            output_dim=output_size,
+            hidden_dim=ffn_config.get("hidden_dim", hidden_dim),
+            n_layers=ffn_config.get("n_layers", 1),
+            dropout=ffn_config.get("dropout", dropout),
+            activation=ffn_config.get("activation", activation),
+        )
 
         self.optimizer_class = optimizer_class
         self.optimizer_params = optimizer_params if optimizer_params else {}
@@ -93,26 +95,34 @@ class CMPNNLightningModule(pl.LightningModule):
         initialize_weights(self)
 
         if metrics is None:
-            self.metrics = nn.ModuleDict({
-                "RMSE": torchmetrics.MeanSquaredError(squared=False),
-                "MAE": torchmetrics.MeanAbsoluteError(),
-                "R2": torchmetrics.R2Score(),
-            })
+            self.metrics = nn.ModuleDict(
+                {
+                    "RMSE": torchmetrics.MeanSquaredError(squared=False),
+                    "MAE": torchmetrics.MeanAbsoluteError(),
+                    "R2": torchmetrics.R2Score(),
+                }
+            )
         else:
             self.metrics = nn.ModuleDict(metrics)
 
-    def forward(self, f_atoms: torch.Tensor, f_bonds: torch.Tensor,
-                a2b: torch.Tensor, b2a: torch.Tensor, b2revb: torch.Tensor,
-                a_scope: torch.Tensor,
-                global_features: torch.Tensor = None) -> torch.Tensor:
+    def forward(
+        self,
+        f_atoms: torch.Tensor,
+        f_bonds: torch.Tensor,
+        a2b: torch.Tensor,
+        b2a: torch.Tensor,
+        b2revb: torch.Tensor,
+        a_scope: torch.Tensor,
+        global_features: torch.Tensor = None,
+    ) -> torch.Tensor:
         """
         Forward pass through the model.
-        
+
         Args:
             f_atoms: Atom features.
             f_bonds: Bond features.
             global_features: Global features.
-        
+
         Returns:
             Output tensor.
         """
@@ -123,7 +133,7 @@ class CMPNNLightningModule(pl.LightningModule):
             a2b=a2b,
             b2a=b2a,
             b2revb=b2revb,
-            a_scope=a_scope
+            a_scope=a_scope,
         )
 
         # Aggregate atom features to molecule features
@@ -141,11 +151,11 @@ class CMPNNLightningModule(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         """
         Training step for the model.
-        
+
         Args:
             batch: Batch of data.
             batch_idx: Batch index.
-        
+
         Returns:
             Loss value.
         """
@@ -157,10 +167,14 @@ class CMPNNLightningModule(pl.LightningModule):
         b2revb = batch.b2revb
         a_scope = batch.a_scope
         targets = batch.y
-        global_features = batch.global_features if hasattr(batch, 'global_features') else None
+        global_features = (
+            batch.global_features if hasattr(batch, "global_features") else None
+        )
 
         # Forward pass
-        output = self(atom_features, bond_features, a2b, b2a, b2revb, a_scope, global_features)
+        output = self(
+            atom_features, bond_features, a2b, b2a, b2revb, a_scope, global_features
+        )
         if targets.dim() == 1:
             targets = targets.unsqueeze(1)
 
@@ -168,18 +182,18 @@ class CMPNNLightningModule(pl.LightningModule):
         loss = F.mse_loss(output, targets)
 
         # Log metrics
-        self.log('train_loss', loss, prog_bar=True, batch_size=targets.size(0))
+        self.log("train_loss", loss, prog_bar=True, batch_size=targets.size(0))
 
         return loss
 
     def validation_step(self, batch, batch_idx):
         """
         Validation step for the model.
-        
+
         Args:
             batch: Batch of data.
             batch_idx: Batch index.
-        
+
         Returns:
             Loss value.
         """
@@ -191,9 +205,13 @@ class CMPNNLightningModule(pl.LightningModule):
         b2revb = batch.b2revb
         a_scope = batch.a_scope
         targets = batch.y
-        global_features = batch.global_features if hasattr(batch, 'global_features') else None
+        global_features = (
+            batch.global_features if hasattr(batch, "global_features") else None
+        )
         # Forward pass
-        output = self(atom_features, bond_features, a2b, b2a, b2revb, a_scope, global_features)
+        output = self(
+            atom_features, bond_features, a2b, b2a, b2revb, a_scope, global_features
+        )
 
         if targets.dim() == 1:
             targets = targets.unsqueeze(1)
@@ -202,7 +220,7 @@ class CMPNNLightningModule(pl.LightningModule):
         loss = self.loss_fn(output, targets)
 
         # Log metrics
-        self.log('val_loss', loss, prog_bar=True, batch_size=targets.size(0))
+        self.log("val_loss", loss, prog_bar=True, batch_size=targets.size(0))
 
         return loss
 
@@ -218,11 +236,11 @@ class CMPNNLightningModule(pl.LightningModule):
     def test_step(self, batch, batch_idx):
         """
         Test step for the model.
-        
+
         Args:
             batch: Batch of data.
             batch_idx: Batch index.
-        
+
         Returns:
             Loss value.
         """
@@ -234,22 +252,26 @@ class CMPNNLightningModule(pl.LightningModule):
         b2revb = batch.b2revb
         a_scope = batch.a_scope
         targets = batch.y
-        global_features = batch.global_features if hasattr(batch, 'global_features') else None
+        global_features = (
+            batch.global_features if hasattr(batch, "global_features") else None
+        )
 
         # Forward pass
-        output = self(atom_features, bond_features, a2b, b2a, b2revb, a_scope, global_features)
+        output = self(
+            atom_features, bond_features, a2b, b2a, b2revb, a_scope, global_features
+        )
 
         if targets.dim() == 1:
             targets = targets.unsqueeze(1)
 
-        self.test_outputs.append({"preds": output.detach(), "targets": targets.detach()})
+        self.test_outputs.append(
+            {"preds": output.detach(), "targets": targets.detach()}
+        )
         return {}
 
     def configure_optimizers(self):
         optimizer = self.optimizer_class(
-            self.parameters(),
-            lr=self.learning_rate,
-            **self.optimizer_params
+            self.parameters(), lr=self.learning_rate, **self.optimizer_params
         )
         self.optimizer_instance = optimizer  # Save it for use in on_train_end
         return optimizer
@@ -260,6 +282,7 @@ class CMPNNLightningModule(pl.LightningModule):
         optimizer = self.trainer.optimizers[0]
         if isinstance(optimizer, NoamLikeOptimizer):
             import os
+
             log_dir = self.trainer.logger.log_dir if self.trainer.logger else "."
             path = os.path.join(log_dir, "lr_schedule.png")
             optimizer.plot_lr_schedule(save_path=path)
@@ -280,15 +303,15 @@ class CMPNNLightningModule(pl.LightningModule):
     def loss_fn(self, predictions, targets):
         """
         Compute the loss between predictions and targets.
-        
+
         Args:
             predictions: Model predictions.
             targets: Ground truth targets.
-        
+
         Returns:
             Loss value.
         """
-        if self.prediction_type == 'classification':
+        if self.prediction_type == "classification":
             loss = nn.BCEWithLogitsLoss()(predictions, targets)
         else:
             loss = nn.MSELoss()(predictions, targets)
@@ -325,60 +348,84 @@ class MultiCMPNNLightningModule(pl.LightningModule):
     A PyTorch Lightning module for multiple CMPNN Encoder model.
     """
 
-    def __init__(self,
-                 atom_fdim: int = 133,
-                 bond_fdim: int = 14,
-                 global_fdim: int = 0,
-                 shared_encoder: bool = False,
-                 n_components: int = 2,
-                 atom_messages: bool = True,
-                 depth: int = 3,
-                 output_size: int = 1,
-                 hidden_dim: int = 128,
-                 dropout: float = 0.1,
-                 activation: str = 'relu',
-                 bias: bool = False,
-                 booster: str = 'sum',
-                 comm_mode: str = 'add',
-                 prediction_type: str = 'regression',
-                 aggregator: str = 'mean',
-                 use_batch_norm: bool = False,
-                 ffn_config: dict = None,
-                 optimizer_class: type = torch.optim.Adam,
-                 optimizer_params: dict = None,
-                 learning_rate: float = 1e-3,
-                 metrics: dict = None,
-                 plot_lr: bool = False):
+    def __init__(
+        self,
+        atom_fdim: int = 133,
+        bond_fdim: int = 14,
+        global_fdim: int = 0,
+        shared_encoder: bool = False,
+        n_components: int = 2,
+        atom_messages: bool = True,
+        depth: int = 3,
+        output_size: int = 1,
+        hidden_dim: int = 128,
+        dropout: float = 0.1,
+        activation: str = "relu",
+        bias: bool = False,
+        booster: str = "sum",
+        comm_mode: str = "add",
+        prediction_type: str = "regression",
+        aggregator: str = "mean",
+        use_batch_norm: bool = False,
+        ffn_config: dict = None,
+        optimizer_class: type = torch.optim.Adam,
+        optimizer_params: dict = None,
+        learning_rate: float = 1e-3,
+        metrics: dict = None,
+        plot_lr: bool = False,
+    ):
         super().__init__()
         self.save_hyperparameters()
         self.output_size = output_size
         self.prediction_type = prediction_type
         self.plot_lr = plot_lr
-        if self.prediction_type == 'classification':
+        if self.prediction_type == "classification":
             self.sigmoid = nn.Sigmoid()
         self.shared_encoder = shared_encoder
 
         if shared_encoder:
-            self.encoders = nn.ModuleList([CMPNNEncoder(atom_fdim, bond_fdim, atom_messages=atom_messages,
-                                                        depth=depth, hidden_dim=hidden_dim,
-                                                        dropout=dropout, activation=activation,
-                                                        bias=bias, booster=booster, comm_mode=comm_mode)]
-                                          * n_components)
+            self.encoders = nn.ModuleList(
+                [
+                    CMPNNEncoder(
+                        atom_fdim,
+                        bond_fdim,
+                        atom_messages=atom_messages,
+                        depth=depth,
+                        hidden_dim=hidden_dim,
+                        dropout=dropout,
+                        activation=activation,
+                        bias=bias,
+                        booster=booster,
+                        comm_mode=comm_mode,
+                    )
+                ]
+                * n_components
+            )
         else:
-            self.encoders = nn.ModuleList([
-                CMPNNEncoder(atom_fdim, bond_fdim, atom_messages=atom_messages,
-                             depth=depth, hidden_dim=hidden_dim,
-                             dropout=dropout, activation=activation,
-                             bias=bias, booster=booster, comm_mode=comm_mode)
-                for _ in range(n_components)
-            ])
+            self.encoders = nn.ModuleList(
+                [
+                    CMPNNEncoder(
+                        atom_fdim,
+                        bond_fdim,
+                        atom_messages=atom_messages,
+                        depth=depth,
+                        hidden_dim=hidden_dim,
+                        dropout=dropout,
+                        activation=activation,
+                        bias=bias,
+                        booster=booster,
+                        comm_mode=comm_mode,
+                    )
+                    for _ in range(n_components)
+                ]
+            )
 
         # Set the aggregator
-        if aggregator == 'mean':
+        if aggregator == "mean":
             self.aggregator = MeanAggregator()
-        elif aggregator == 'sum':
+        elif aggregator == "sum":
             self.aggregator = SumAggregator()
-        elif aggregator == 'norm_mean':
+        elif aggregator == "norm_mean":
             self.aggregator = NormMeanAggregator()
         else:
             raise ValueError(f"Unknown aggregator: {aggregator}")
@@ -388,13 +435,14 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         ffn_input_dim = (hidden_dim + global_fdim) * n_components
         ffn_config = ffn_config if ffn_config else {}
 
-        self.ffn = MLP(input_dim=ffn_input_dim,
-                       output_dim=output_size,
-                       hidden_dim=ffn_config.get('hidden_dim', hidden_dim),
-                       n_layers=ffn_config.get('n_layers', 1),
-                       dropout=ffn_config.get('dropout', dropout),
-                       activation=ffn_config.get('activation', activation)
-                       )
+        self.ffn = MLP(
+            input_dim=ffn_input_dim,
+            output_dim=output_size,
+            hidden_dim=ffn_config.get("hidden_dim", hidden_dim),
+            n_layers=ffn_config.get("n_layers", 1),
+            dropout=ffn_config.get("dropout", dropout),
+            activation=ffn_config.get("activation", activation),
+        )
 
         self.optimizer_class = optimizer_class
         self.optimizer_params = optimizer_params if optimizer_params else {}
@@ -404,11 +452,13 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         initialize_weights(self)
 
         if metrics is None:
-            self.metrics = nn.ModuleDict({
-                "RMSE": torchmetrics.MeanSquaredError(squared=False),
-                "MAE": torchmetrics.MeanAbsoluteError(),
-                "R2": torchmetrics.R2Score(),
-            })
+            self.metrics = nn.ModuleDict(
+                {
+                    "RMSE": torchmetrics.MeanSquaredError(squared=False),
+                    "MAE": torchmetrics.MeanAbsoluteError(),
+                    "R2": torchmetrics.R2Score(),
+                }
+            )
         else:
             self.metrics = nn.ModuleDict(metrics)
 
@@ -423,7 +473,7 @@ class MultiCMPNNLightningModule(pl.LightningModule):
                 a2b=comp.a2b,
                 b2a=comp.b2a,
                 b2revb=comp.b2revb,
-                a_scope=comp.a_scope
+                a_scope=comp.a_scope,
             )
 
             mol_vector = self.aggregator(atom_hidden, comp.a_scope)
@@ -441,11 +491,11 @@ class MultiCMPNNLightningModule(pl.LightningModule):
     def training_step(self, batch, batch_idx):
         """
         Training step for the model.
-        
+
         Args:
             batch: Batch of data.
             batch_idx: Batch index.
-        
+
         Returns:
             Loss value.
         """
@@ -456,17 +506,17 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         # Compute loss
         loss = F.mse_loss(output, targets)
         # Log metrics
-        self.log('train_loss', loss, prog_bar=True, batch_size=targets.size(0))
+        self.log("train_loss", loss, prog_bar=True, batch_size=targets.size(0))
         return loss
 
     def validation_step(self, batch, batch_idx):
         """
         Validation step for the model.
-        
+
         Args:
             batch: Batch of data.
             batch_idx: Batch index.
-        
+
         Returns:
             Loss value.
         """
@@ -477,7 +527,7 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         # Compute loss
         loss = F.mse_loss(output, targets)
         # Log metrics
-        self.log('val_loss', loss, prog_bar=True, batch_size=targets.size(0))
+        self.log("val_loss", loss, prog_bar=True, batch_size=targets.size(0))
         return loss
 
     def on_test_epoch_start(self):
@@ -492,11 +542,11 @@ class MultiCMPNNLightningModule(pl.LightningModule):
     def test_step(self, batch, batch_idx):
         """
         Test step for the model.
-        
+
         Args:
             batch: Batch of data.
             batch_idx: Batch index.
-        
+
         Returns:
             Loss value.
         """
@@ -504,14 +554,14 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         targets = batch.y
         if targets.dim() == 1:
             targets = targets.unsqueeze(1)
-        self.test_outputs.append({"preds": output.detach(), "targets": targets.detach()})
+        self.test_outputs.append(
+            {"preds": output.detach(), "targets": targets.detach()}
+        )
         return {}
 
     def configure_optimizers(self):
         optimizer = self.optimizer_class(
-            self.parameters(),
-            lr=self.learning_rate,
-            **self.optimizer_params
+            self.parameters(), lr=self.learning_rate, **self.optimizer_params
         )
         self.optimizer_instance = optimizer
         return optimizer
@@ -522,6 +572,7 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         optimizer = self.trainer.optimizers[0]
         if isinstance(optimizer, NoamLikeOptimizer):
             import os
+
             log_dir = self.trainer.logger.log_dir if self.trainer.logger else "."
             path = os.path.join(log_dir, "lr_schedule.png")
             optimizer.plot_lr_schedule(save_path=path)
@@ -549,7 +600,7 @@ class MultiCMPNNLightningModule(pl.LightningModule):
         Returns:
             Loss value.
         """
-        if self.prediction_type == 'classification':
+        if self.prediction_type == "classification":
             loss = nn.BCEWithLogitsLoss()(predictions, targets)
         else:
             loss = nn.MSELoss()(predictions, targets)

--- a/cmpnn/models/lightning.py
+++ b/cmpnn/models/lightning.py
@@ -59,6 +59,7 @@ class CMPNNLightningModule(pl.LightningModule):
             atom_messages=atom_messages,
             booster=booster,
             comm_mode=comm_mode,
+            use_batch_norm=use_batch_norm,
         )
 
         # Set the aggregator

--- a/setup_device_torch.sh
+++ b/setup_device_torch.sh
@@ -7,30 +7,52 @@ set -e
 echo "Choose backend: [cpu, cuda, rocm]"
 read -r backend
 
-if [[ "$backend" == "cuda" ]]; then
-    echo "Installing PyTorch (CUDA 12.6)"
-    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
-    pip install torch_geometric
-    pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.6.0+cu126.html
-    pip install lightning
+if [[ $backend == "cuda" ]]; then
+	echo "Choose CUDA version for PyTorch 2.6.0 [11.8, 12.4, 12.6]"
+	read -r cuda_ver
 
-elif [[ "$backend" == "cpu" ]]; then
-    echo "Installing PyTorch (CPU)"
-    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-    pip install torch_geometric
-    pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
-    pip install lightning
+	case "$cuda_ver" in
+	12.6 | 12.6.0)
+		CUDA_TAG="cu126"
+		PYG_URL="https://data.pyg.org/whl/torch-2.6.0+cu126.html"
+		;;
+	12.4 | 12.4.0)
+		CUDA_TAG="cu124"
+		PYG_URL="https://data.pyg.org/whl/torch-2.6.0+cu124.html"
+		;;
+	11.8 | 11.8.0)
+		CUDA_TAG="cu118"
+		PYG_URL="https://data.pyg.org/whl/torch-2.6.0+cu118.html"
+		;;
+	*)
+		echo "Invalid CUDA version: choose one of [11.8, 12.4, 12.6]"
+		exit 1
+		;;
+	esac
 
-elif [[ "$backend" == "rocm" ]]; then
-    echo "Installing PyTorch (ROCm 6.2.4)"
-    pip install torch==2.6.0+rocm6.2.4 torchvision==0.21.0+rocm6.2.4 torchaudio==2.6.0+rocm6.2.4 --index-url https://download.pytorch.org/whl/rocm6.2.4
-    pip install lightning
-    echo "Downloading PyG ROCm wheels"
-    wget https://github.com/Looong01/pyg-rocm-build/releases/download/9/torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
-    unzip torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
-    pip install torch_*.whl
+	echo "Installing PyTorch (CUDA ${cuda_ver})"
+	pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/${CUDA_TAG}
+	pip install torch_geometric
+	pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f ${PYG_URL}
+	pip install lightning
+
+elif [[ $backend == "cpu" ]]; then
+	echo "Installing PyTorch (CPU)"
+	pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cpu
+	pip install torch_geometric
+	pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+	pip install lightning
+
+elif [[ $backend == "rocm" ]]; then
+	echo "Installing PyTorch (ROCm 6.2.4)"
+	pip install torch==2.6.0+rocm6.2.4 torchvision==0.21.0+rocm6.2.4 torchaudio==2.6.0+rocm6.2.4 --index-url https://download.pytorch.org/whl/rocm6.2.4
+	pip install lightning
+	echo "Downloading PyG ROCm wheels"
+	wget https://github.com/Looong01/pyg-rocm-build/releases/download/9/torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
+	unzip torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
+	pip install torch_*.whl
 
 else
-    echo "Invalid backend: choose one of [cpu, cuda, rocm]"
-    exit 1
+	echo "Invalid backend: choose one of [cpu, cuda, rocm]"
+	exit 1
 fi

--- a/tests/featurizer/test_utils.py
+++ b/tests/featurizer/test_utils.py
@@ -30,4 +30,3 @@ def test_extra_atom_features_propagate_to_bonds():
     # bond features begin with the corresponding atom feature vector
     assert torch.allclose(data.f_bonds[0][: data.f_atoms.shape[1]], data.f_atoms[0])
     assert torch.allclose(data.f_bonds[1][: data.f_atoms.shape[1]], data.f_atoms[1])
-

--- a/tests/featurizer/test_utils.py
+++ b/tests/featurizer/test_utils.py
@@ -1,0 +1,33 @@
+import numpy as np
+import torch
+
+from cmpnn.featurizer.utils import featurize_molecule
+from cmpnn.featurizer.atom_bond import AtomFeaturizer, BondFeaturizer
+
+
+def test_extra_atom_features_propagate_to_bonds():
+    smiles = "CC"  # ethane has one bond
+    af = AtomFeaturizer()
+    bf = BondFeaturizer()
+
+    extra = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+
+    data = featurize_molecule(
+        smiles=smiles,
+        target=0.0,
+        atom_featurizer=af,
+        bond_featurizer=bf,
+        atom_messages=False,
+        extra_atom_features=extra,
+    )
+
+    # atoms include extra descriptors
+    assert data.f_atoms.shape[1] == len(af) + extra.shape[1]
+
+    # bond feature dimension reflects augmented atom features
+    assert data.f_bonds.shape[1] == data.f_atoms.shape[1] + len(bf)
+
+    # bond features begin with the corresponding atom feature vector
+    assert torch.allclose(data.f_bonds[0][: data.f_atoms.shape[1]], data.f_atoms[0])
+    assert torch.allclose(data.f_bonds[1][: data.f_atoms.shape[1]], data.f_atoms[1])
+


### PR DESCRIPTION
## Summary
- Activate optional batch normalization inside `CMPNNEncoder` and surface the flag through the Lightning module
- Allow molecule datasets to append per-atom descriptors from CSVs using `rxn_id` and `mol_type`
- Extend featurization utilities to merge these extra atom features into the graph representation