### PR TITLE
Enable post-split feature and target transformations

### DIFF
--- a/cmpnn/data/__init__.py
+++ b/cmpnn/data/__init__.py
@@ -1,0 +1,3 @@
+from .dataset_holder import MoleculeDatasetHolder, MultiMoleculeDatasetHolder
+
+__all__ = ["MoleculeDatasetHolder", "MultiMoleculeDatasetHolder"]

--- a/cmpnn/data/dataset_holder.py
+++ b/cmpnn/data/dataset_holder.py
@@ -1,0 +1,171 @@
+import numpy as np
+import torch
+from typing import List, Optional, Sequence
+
+
+class MoleculeDatasetHolder:
+    """Utility to split a :class:`MoleculeDataset` and apply column wise
+    transformations to both features and targets.
+
+    Parameters
+    ----------
+    dataset: MoleculeDataset
+        Dataset containing :class:`cmpnn.data.molecule_data.MoleculeData` items.
+    """
+
+    def __init__(self, dataset):
+        self.dataset = dataset
+        self.feature_transformer = None
+        self.target_transformers: Optional[Sequence] = None
+
+    def split(
+        self,
+        splitter,
+        train_frac: float = 0.8,
+        val_frac: float = 0.1,
+        test_frac: float = 0.1,
+        feature_transformer=None,
+        target_transformers: Optional[Sequence] = None,
+    ):
+        """Split the dataset and optionally apply transforms.
+
+        Parameters
+        ----------
+        splitter: BaseSplitter
+            Instance of a splitter implementing ``split`` returning the
+            train/val/test ``MoleculeData`` lists.
+        train_frac, val_frac, test_frac: float
+            Fractions for each split.
+        feature_transformer: sklearn-style transformer, optional
+            Transformer applied to ``global_features`` of each item.
+            Expected to implement ``fit`` and ``transform``.
+        target_transformers: sequence of sklearn-style transformers, optional
+            One transformer per target column. Each must implement ``fit`` and
+            ``transform``.
+        """
+
+        train_data, val_data, test_data = splitter.split(
+            self.dataset, train_frac=train_frac, val_frac=val_frac, test_frac=test_frac
+        )
+
+        self.feature_transformer = feature_transformer
+        self.target_transformers = target_transformers
+
+        if self.feature_transformer is not None:
+            self._fit_feature_transformer(train_data)
+            for split in (train_data, val_data, test_data):
+                self._apply_feature_transform(split)
+
+        if self.target_transformers is not None:
+            self._fit_target_transformers(train_data)
+            for split in (train_data, val_data, test_data):
+                self._apply_target_transform(split)
+
+        return train_data, val_data, test_data
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _collect_features(self, data_list: List) -> np.ndarray:
+        feats = [d.global_features.numpy() for d in data_list]
+        return np.vstack(feats)
+
+    def _collect_targets(self, data_list: List) -> np.ndarray:
+        targets = [d.y.numpy() for d in data_list]
+        return np.vstack(targets)
+
+    def _fit_feature_transformer(self, train_data: List) -> None:
+        X = self._collect_features(train_data)
+        self.feature_transformer.fit(X)
+
+    def _apply_feature_transform(self, data_list: List) -> None:
+        for d in data_list:
+            arr = d.global_features.numpy().reshape(1, -1)
+            transformed = self.feature_transformer.transform(arr)
+            d.global_features = torch.tensor(
+                transformed.squeeze(), dtype=torch.float32
+            )
+
+    def _fit_target_transformers(self, train_data: List) -> None:
+        Y = self._collect_targets(train_data)
+        for i, transformer in enumerate(self.target_transformers):
+            transformer.fit(Y[:, [i]])
+
+    def _apply_target_transform(self, data_list: List) -> None:
+        for d in data_list:
+            y = d.y.numpy().reshape(1, -1)
+            cols = [t.transform(y[:, [i]]) for i, t in enumerate(self.target_transformers)]
+            transformed = np.hstack(cols)
+            d.y = torch.tensor(transformed.squeeze(), dtype=torch.float32)
+
+
+class MultiMoleculeDatasetHolder:
+    """Same as :class:`MoleculeDatasetHolder` but for
+    :class:`cmpnn.featurizer.molecule_dataset.MultiMoleculeDataset` items.
+    ``feature_transformers`` must be a sequence with one transformer per
+    component in the dataset.
+    """
+
+    def __init__(self, dataset):
+        self.dataset = dataset
+        self.feature_transformers: Optional[Sequence] = None
+        self.target_transformers: Optional[Sequence] = None
+
+    def split(
+        self,
+        splitter,
+        train_frac: float = 0.8,
+        val_frac: float = 0.1,
+        test_frac: float = 0.1,
+        feature_transformers: Optional[Sequence] = None,
+        target_transformers: Optional[Sequence] = None,
+    ):
+        train_data, val_data, test_data = splitter.split(
+            self.dataset, train_frac=train_frac, val_frac=val_frac, test_frac=test_frac
+        )
+
+        self.feature_transformers = feature_transformers
+        self.target_transformers = target_transformers
+
+        if self.feature_transformers is not None:
+            for idx, transformer in enumerate(self.feature_transformers):
+                X = self._collect_features(train_data, idx)
+                transformer.fit(X)
+            for split in (train_data, val_data, test_data):
+                for idx, _ in enumerate(self.feature_transformers):
+                    self._apply_feature_transform(split, idx)
+
+        if self.target_transformers is not None:
+            Y = self._collect_targets(train_data)
+            for i, transformer in enumerate(self.target_transformers):
+                transformer.fit(Y[:, [i]])
+            for split in (train_data, val_data, test_data):
+                self._apply_target_transform(split)
+
+        return train_data, val_data, test_data
+
+    # Helpers ------------------------------------------------------------
+    def _collect_features(self, data_list: List, comp_idx: int) -> np.ndarray:
+        feats = [sample[comp_idx].global_features.numpy() for sample in data_list]
+        return np.vstack(feats)
+
+    def _apply_feature_transform(self, data_list: List, comp_idx: int) -> None:
+        transformer = self.feature_transformers[comp_idx]
+        for sample in data_list:
+            arr = sample[comp_idx].global_features.numpy().reshape(1, -1)
+            transformed = transformer.transform(arr)
+            sample[comp_idx].global_features = torch.tensor(
+                transformed.squeeze(), dtype=torch.float32
+            )
+
+    def _collect_targets(self, data_list: List) -> np.ndarray:
+        targets = [sample[0].y.numpy() for sample in data_list]
+        return np.vstack(targets)
+
+    def _apply_target_transform(self, data_list: List) -> None:
+        for sample in data_list:
+            y = sample[0].y.numpy().reshape(1, -1)
+            cols = [t.transform(y[:, [i]]) for i, t in enumerate(self.target_transformers)]
+            transformed = np.hstack(cols)
+            new_tensor = torch.tensor(transformed.squeeze(), dtype=torch.float32)
+            for comp in sample:
+                comp.y = new_tensor.clone()

--- a/cmpnn/featurizer/utils.py
+++ b/cmpnn/featurizer/utils.py
@@ -100,6 +100,12 @@ def featurize_molecule(
     if global_featurizer is not None:
         global_features = torch.tensor(global_featurizer(smiles), dtype=torch.float)
 
+    # Ensure target is a floating tensor with shape ``(n_targets,)``
+    if torch.is_tensor(target):
+        y_tensor = target.float()
+    else:
+        y_tensor = torch.tensor([target], dtype=torch.float32)
+
     # Create MoleculeData object
     return MoleculeData(
         f_atoms=f_atoms,
@@ -109,7 +115,7 @@ def featurize_molecule(
         a_scope=a_scope,
         b_scope=b_scope,
         global_features=global_features,
-        y=torch.tensor([target], dtype=torch.float),
+        y=y_tensor,
         bonds=bonds,
         smiles=smiles,
         b2revb=b2revb,

--- a/tests/data/test_dataset_holder.py
+++ b/tests/data/test_dataset_holder.py
@@ -1,0 +1,162 @@
+import os
+import tempfile
+import numpy as np
+import pandas as pd
+import torch
+
+from sklearn.compose import ColumnTransformer
+from sklearn.kernel_approximation import RBFSampler
+from sklearn.preprocessing import PowerTransformer, StandardScaler
+
+from cmpnn.featurizer.atom_bond import AtomFeaturizer, BondFeaturizer
+from cmpnn.featurizer.molecule_dataset import MoleculeDataset, MultiMoleculeDataset
+from cmpnn.data.dataset_holder import MoleculeDatasetHolder, MultiMoleculeDatasetHolder
+from cmpnn.split.random import RandomSplitter
+
+
+class LengthFeaturizer:
+    def __call__(self, smiles: str):
+        return np.array([len(smiles)], dtype=float)
+
+
+def create_csv(single=True):
+    if single:
+        data = {
+            "smiles": ["C", "CC", "CCC", "CCCC", "CCCCC"],
+            "t1": [1, 2, 3, 4, 5],
+            "t2": [2, 3, 4, 5, 6],
+            "t3": [3, 4, 5, 6, 7],
+        }
+    else:
+        data = {
+            "smiles1": ["C", "CC", "CCC", "CCCC", "CCCCC"],
+            "smiles2": ["O", "N", "F", "Cl", "Br"],
+            "t1": [1, 2, 3, 4, 5],
+            "t2": [2, 3, 4, 5, 6],
+            "t3": [3, 4, 5, 6, 7],
+        }
+    df = pd.DataFrame(data)
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
+    df.to_csv(tmp.name, index=False)
+    return tmp.name, df
+
+
+def test_molecule_dataset_holder_transforms():
+    csv_path, df = create_csv(single=True)
+    dataset = MoleculeDataset(
+        csv_file=csv_path,
+        smiles_col="smiles",
+        target_cols=["t1", "t2", "t3"],
+        atom_featurizer=AtomFeaturizer(),
+        bond_featurizer=BondFeaturizer(),
+        global_featurizer=LengthFeaturizer(),
+        use_cache=False,
+    )
+
+    orig_feats = {dataset[i].smiles: dataset[i].global_features.clone() for i in range(len(dataset))}
+    orig_targets = {dataset[i].smiles: dataset[i].y.clone() for i in range(len(dataset))}
+
+    splitter = RandomSplitter(seed=0)
+    feature_tf = ColumnTransformer(
+        [
+            ("rbf", RBFSampler(gamma=0.5, n_components=2, random_state=0), [0]),
+        ]
+    )
+    target_tfs = [StandardScaler(), StandardScaler(), PowerTransformer(method="yeo-johnson")]
+
+    holder = MoleculeDatasetHolder(dataset)
+    train, val, test = holder.split(
+        splitter,
+        train_frac=0.6,
+        val_frac=0.2,
+        test_frac=0.2,
+        feature_transformer=feature_tf,
+        target_transformers=target_tfs,
+    )
+
+    # Check shapes
+    for split in [train, val, test]:
+        for d in split:
+            assert d.global_features.shape[0] == 2
+            assert d.y.shape[0] == 3
+
+    # Verify transformation correctness
+    for split in [train, val, test]:
+        for d in split:
+            smi = d.smiles
+            feat_expected = holder.feature_transformer.transform(orig_feats[smi].numpy().reshape(1, -1)).squeeze()
+            np.testing.assert_allclose(d.global_features.numpy(), feat_expected, rtol=1e-6)
+
+            y_orig = orig_targets[smi].numpy().reshape(1, -1)
+            cols = [holder.target_transformers[i].transform(y_orig[:, [i]]) for i in range(3)]
+            y_expected = np.hstack(cols).squeeze()
+            np.testing.assert_allclose(d.y.numpy(), y_expected, rtol=1e-6)
+
+    train_y = np.stack([d.y.numpy() for d in train])
+    assert abs(train_y[:, 0].mean()) < 1e-7
+
+    os.remove(csv_path)
+
+
+def test_multi_molecule_dataset_holder_transforms():
+    csv_path, df = create_csv(single=False)
+    dataset = MultiMoleculeDataset(
+        csv_file=csv_path,
+        smiles_cols=["smiles1", "smiles2"],
+        target_cols=["t1", "t2", "t3"],
+        atom_featurizer=AtomFeaturizer(),
+        bond_featurizer=BondFeaturizer(),
+        global_featurizer=LengthFeaturizer(),
+        use_cache=False,
+    )
+
+    orig_feats1 = {}
+    orig_feats2 = {}
+    orig_targets = {}
+    for i in range(len(dataset)):
+        c1, c2 = dataset[i]
+        key = c1.smiles
+        orig_feats1[key] = c1.global_features.clone()
+        orig_feats2[key] = c2.global_features.clone()
+        orig_targets[key] = c1.y.clone()
+
+    splitter = RandomSplitter(seed=0)
+    ft1 = ColumnTransformer([
+        ("rbf", RBFSampler(gamma=0.5, n_components=2, random_state=0), [0]),
+    ])
+    ft2 = ColumnTransformer([
+        ("rbf", RBFSampler(gamma=0.5, n_components=2, random_state=1), [0]),
+    ])
+    target_tfs = [StandardScaler(), StandardScaler(), PowerTransformer(method="yeo-johnson")]
+
+    holder = MultiMoleculeDatasetHolder(dataset)
+    train, val, test = holder.split(
+        splitter,
+        train_frac=0.6,
+        val_frac=0.2,
+        test_frac=0.2,
+        feature_transformers=[ft1, ft2],
+        target_transformers=target_tfs,
+    )
+
+    for split in [train, val, test]:
+        for sample in split:
+            for comp in sample:
+                assert comp.global_features.shape[0] == 2
+                assert comp.y.shape[0] == 3
+
+    for split in [train, val, test]:
+        for sample in split:
+            key = sample[0].smiles
+            feat1_exp = holder.feature_transformers[0].transform(orig_feats1[key].numpy().reshape(1, -1)).squeeze()
+            feat2_exp = holder.feature_transformers[1].transform(orig_feats2[key].numpy().reshape(1, -1)).squeeze()
+            np.testing.assert_allclose(sample[0].global_features.numpy(), feat1_exp, rtol=1e-6)
+            np.testing.assert_allclose(sample[1].global_features.numpy(), feat2_exp, rtol=1e-6)
+
+            y_orig = orig_targets[key].numpy().reshape(1, -1)
+            cols = [holder.target_transformers[i].transform(y_orig[:, [i]]) for i in range(3)]
+            y_expected = np.hstack(cols).squeeze()
+            np.testing.assert_allclose(sample[0].y.numpy(), y_expected, rtol=1e-6)
+            np.testing.assert_allclose(sample[1].y.numpy(), y_expected, rtol=1e-6)
+
+    os.remove(csv_path)


### PR DESCRIPTION
## Summary
- add dataset holders that apply feature and target transformers after splitting
- allow `featurize_molecule` to handle multi-dimensional targets
- test transformation workflow for single and multi-component datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf5c40454832282f4f32dad19af84