### PR TITLE
Add atom descriptor scaler and unscaler implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -q
+        run: pytest -q -vv -s

--- a/cmpnn/__init__.py
+++ b/cmpnn/__init__.py
@@ -1,9 +1,3 @@
-from . import data, featurizer, models, optimizer, split
+from . import data, featurizer, models, optimizer, split, scaler
 
-__all__ = [
-    "data",
-    "featurizer",
-    "models",
-    "optimizer",
-    "split"
-]
+__all__ = ["data", "featurizer", "models", "optimizer", "split", "scaler"]

--- a/cmpnn/data/dataset_holder.py
+++ b/cmpnn/data/dataset_holder.py
@@ -1,6 +1,35 @@
 import numpy as np
 import torch
 from typing import List, Optional, Sequence
+from cmpnn.scaler.unscalers import ColumnUnscaler
+
+
+def _ensure_raw_single(obj) -> None:
+    if hasattr(obj, "y") and obj.y is not None and not hasattr(obj, "y_raw"):
+        obj.y_raw = obj.y.detach().clone()
+    if (
+        hasattr(obj, "global_features")
+        and obj.global_features is not None
+        and not hasattr(obj, "global_features_raw")
+    ):
+        obj.global_features_raw = obj.global_features.detach().clone()
+    if (
+        hasattr(obj, "f_atoms")
+        and obj.f_atoms is not None
+        and not hasattr(obj, "f_atoms_raw")
+    ):
+        obj.f_atoms_raw = obj.f_atoms.detach().clone()
+    if (
+        hasattr(obj, "f_bonds")
+        and obj.f_bonds is not None
+        and not hasattr(obj, "f_bonds_raw")
+    ):
+        obj.f_bonds_raw = obj.f_bonds.detach().clone()
+
+
+def _ensure_raw_list(objs: List) -> None:
+    for o in objs:
+        _ensure_raw_single(o)
 
 
 class MoleculeDatasetHolder:
@@ -17,6 +46,9 @@ class MoleculeDatasetHolder:
         self.dataset = dataset
         self.feature_transformer = None
         self.target_transformers: Optional[Sequence] = None
+        self.n_targets_: Optional[int] = None
+        self.extra_atom_start: int = 0
+        self.mirror_into_bonds: Optional[bool] = None  # None = auto-detect
 
     def split(
         self,
@@ -26,6 +58,7 @@ class MoleculeDatasetHolder:
         test_frac: float = 0.1,
         feature_transformer=None,
         target_transformers: Optional[Sequence] = None,
+        atom_desc_scaler=None,
     ):
         """Split the dataset and optionally apply transforms.
 
@@ -47,9 +80,16 @@ class MoleculeDatasetHolder:
         train_data, val_data, test_data = splitter.split(
             self.dataset, train_frac=train_frac, val_frac=val_frac, test_frac=test_frac
         )
+        _ensure_raw_list(train_data)
+        _ensure_raw_list(val_data)
+        _ensure_raw_list(test_data)
 
         self.feature_transformer = feature_transformer
         self.target_transformers = target_transformers
+        self.atom_desc_scaler = atom_desc_scaler
+        self.n_targets_ = (
+            len(target_transformers) if target_transformers is not None else None
+        )  # <-- add this
 
         if self.feature_transformer is not None:
             self._fit_feature_transformer(train_data)
@@ -61,41 +101,171 @@ class MoleculeDatasetHolder:
             for split in (train_data, val_data, test_data):
                 self._apply_target_transform(split)
 
+        if self.atom_desc_scaler is not None:
+            self.atom_desc_scaler.fit(train_data)
+            for split in (train_data, val_data, test_data):
+                self.atom_desc_scaler.transform(split)
         return train_data, val_data, test_data
 
     # ------------------------------------------------------------------
     # Internal helpers
+
+    def _auto_detect_mirror(self, d) -> bool:
+        A = getattr(d, "f_atoms_raw", getattr(d, "f_atoms", None))
+        B = getattr(d, "f_bonds", None)  # use current; raw not needed for layout check
+        b2a = getattr(d, "b2a", None)
+        if A is None or B is None or b2a is None:
+            return False
+        atom_dim = A.shape[1]
+        if B.shape[1] < atom_dim:
+            return False
+        src = torch.as_tensor(b2a, dtype=torch.long, device=A.device)
+
+        return torch.allclose(B[:, :atom_dim], A.index_select(0, src))
+
     def _collect_features(self, data_list: List) -> np.ndarray:
-        feats = [d.global_features.numpy() for d in data_list]
-        return np.vstack(feats)
+        feats = [
+            d.global_features_raw.numpy()
+            for d in data_list
+            if hasattr(d, "global_features_raw")
+        ]
+        return np.vstack(feats) if len(feats) else np.zeros((0,))
+
+    def _collect_extra_atom_column(self, data_list: List, col_idx: int) -> np.ndarray:
+        """Stack one extra column across ALL atoms of ALL molecules -> (N_total_atoms, 1)."""
+        rows = []
+        for d in data_list:
+            A = getattr(d, "f_atoms_raw", None)
+            if A is not None:
+                col = (
+                    A[:, [self.extra_atom_start + col_idx]].cpu().numpy()
+                )  # (n_atoms, 1)
+                if col.size:
+                    rows.append(col)
+        return np.vstack(rows) if rows else np.zeros((0, 1), dtype=np.float32)
 
     def _collect_targets(self, data_list: List) -> np.ndarray:
-        targets = [d.y.numpy() for d in data_list]
-        return np.vstack(targets)
+        targets = [d.y_raw.numpy() for d in data_list if hasattr(d, "y_raw")]
+        return np.vstack(targets) if len(targets) else np.zeros((0,))
 
     def _fit_feature_transformer(self, train_data: List) -> None:
         X = self._collect_features(train_data)
-        self.feature_transformer.fit(X)
+        if X.size:
+            self.feature_transformer.fit(X)
+
+    def _fit_extra_atom_transformers(self, train_data: List) -> None:
+        # Decide mirroring if user did not specify
+        if self.mirror_into_bonds is None:
+            self.mirror_into_bonds = False
+            for d in train_data:
+                if self._auto_detect_mirror(d):
+                    self.mirror_into_bonds = True
+                    break
+        # Fit each per-column transformer
+        for i, tf in enumerate(self.extra_atom_transformers):
+            X = self._collect_extra_atom_column(train_data, i)  # (N_total_atoms, 1)
+            if X.size:
+                tf.fit(X)
+
+    @torch.no_grad()
+    def _apply_extra_atom_transformers(self, data_list: List) -> None:
+        atom_start = self.extra_atom_start
+        do_mirror = bool(self.mirror_into_bonds)
+        for d in data_list:
+            Araw = getattr(d, "f_atoms_raw", None)
+            if Araw is None:
+                continue
+            A = Araw.clone()
+            # transform each extra column independently
+            for i, tf in enumerate(self.extra_atom_transformers):
+                col = Araw[:, [atom_start + i]].cpu().numpy()  # (n_atoms, 1)
+                col_t = tf.transform(col)  # (n_atoms, 1)
+                A[:, atom_start + i] = torch.from_numpy(col_t.squeeze(1)).to(A.dtype)
+            d.f_atoms = A
+
+            if do_mirror:
+                B = getattr(d, "f_bonds", None)
+                b2a = getattr(d, "b2a", None)
+                if B is not None and b2a is not None:
+                    atom_dim = d.f_atoms.shape[1]
+                    if B.shape[1] >= atom_dim:
+                        src = torch.as_tensor(b2a, dtype=torch.long, device=A.device)
+                        B[:, :atom_dim] = d.f_atoms.index_select(0, src)
 
     def _apply_feature_transform(self, data_list: List) -> None:
+        if self.feature_transformer is None:
+            return
         for d in data_list:
-            arr = d.global_features.numpy().reshape(1, -1)
+            if not hasattr(d, "global_features_raw") or d.global_features_raw is None:
+                continue
+            arr = d.global_features_raw.numpy().reshape(1, -1)
             transformed = self.feature_transformer.transform(arr)
-            d.global_features = torch.tensor(
-                transformed.squeeze(), dtype=torch.float32
-            )
+            d.global_features = torch.tensor(transformed.squeeze(), dtype=torch.float32)
 
     def _fit_target_transformers(self, train_data: List) -> None:
         Y = self._collect_targets(train_data)
-        for i, transformer in enumerate(self.target_transformers):
-            transformer.fit(Y[:, [i]])
+        if self.n_targets_ is None and Y.size:
+            self.n_targets_ = Y.shape[1]
+        if self.target_transformers is not None and Y.size:
+            assert self.n_targets_ == len(self.target_transformers), (
+                f"len(target_transformers)={len(self.target_transformers)} "
+                f"but n_targets_={self.n_targets_}"
+            )
+            assert (
+                Y.shape[1] == self.n_targets_
+            ), f"Training targets have {Y.shape[1]} columns, expected {self.n_targets_}"
+            # Optional: Box–Cox domain guard
+            for i, t in enumerate(self.target_transformers):
+                if (
+                    t.__class__.__name__ == "PowerTransformer"
+                    and getattr(t, "method", "") == "box-cox"
+                ):
+                    if not np.all(Y[:, i] > 0):
+                        bad = np.where(Y[:, i] <= 0)[0][:5]
+                        raise ValueError(
+                            f"Box–Cox column {i} has non-positive values at indices {bad.tolist()}"
+                        )
+            for i, transformer in enumerate(self.target_transformers):
+                transformer.fit(Y[:, [i]])
 
     def _apply_target_transform(self, data_list: List) -> None:
+        if self.target_transformers is None:
+            return
         for d in data_list:
-            y = d.y.numpy().reshape(1, -1)
-            cols = [t.transform(y[:, [i]]) for i, t in enumerate(self.target_transformers)]
-            transformed = np.hstack(cols)
-            d.y = torch.tensor(transformed.squeeze(), dtype=torch.float32)
+            if not hasattr(d, "y_raw") or d.y_raw is None:
+                continue
+            y = d.y_raw.numpy().reshape(1, -1)
+            assert self.n_targets_ is not None, "n_targets_ was not initialized"
+            assert (
+                y.shape[1] == self.n_targets_
+            ), f"y has {y.shape[1]} cols but {self.n_targets_} transformers were provided"
+            cols = [
+                t.transform(y[:, [i]]) for i, t in enumerate(self.target_transformers)
+            ]
+            transformed = np.hstack(cols).reshape(-1)
+            d.y = torch.tensor(transformed, dtype=torch.float32)
+
+    # ---- convenience ----
+    def build_target_unscaler(self):
+        return (
+            ColumnUnscaler(self.target_transformers)
+            if self.target_transformers
+            else None
+        )
+
+    def reset_to_raw(self, data_list: Optional[List] = None) -> None:
+        """Restore y/global_features to their raw snapshots."""
+        if data_list is None:
+            data_list = self.dataset
+        for d in data_list:
+            if hasattr(d, "y_raw"):
+                d.y = d.y_raw.detach().clone()
+            if hasattr(d, "global_features_raw"):
+                d.global_features = d.global_features_raw.detach().clone()
+            if hasattr(d, "f_atoms_raw"):
+                d.f_atoms = d.f_atoms_raw.detach().clone()
+            if hasattr(d, "f_bonds_raw"):
+                d.f_bonds = d.f_bonds_raw.detach().clone()
 
 
 class MultiMoleculeDatasetHolder:
@@ -109,6 +279,7 @@ class MultiMoleculeDatasetHolder:
         self.dataset = dataset
         self.feature_transformers: Optional[Sequence] = None
         self.target_transformers: Optional[Sequence] = None
+        self.n_targets_: Optional[int] = None
 
     def split(
         self,
@@ -118,54 +289,171 @@ class MultiMoleculeDatasetHolder:
         test_frac: float = 0.1,
         feature_transformers: Optional[Sequence] = None,
         target_transformers: Optional[Sequence] = None,
+        atom_desc_scaler=None,
     ):
         train_data, val_data, test_data = splitter.split(
             self.dataset, train_frac=train_frac, val_frac=val_frac, test_frac=test_frac
         )
 
+        # 1) snapshot raw once for each component of each sample
+        for split in (train_data, val_data, test_data):
+            for sample in split:
+                for comp in sample:
+                    _ensure_raw_single(comp)
+
+        # 2) store transformers
         self.feature_transformers = feature_transformers
         self.target_transformers = target_transformers
+        self.atom_desc_scaler = atom_desc_scaler
+        self.n_targets_ = (
+            len(target_transformers) if target_transformers is not None else None
+        )
 
+        # 3) FEATURES: fit per component on RAW train; transform from RAW
         if self.feature_transformers is not None:
             for idx, transformer in enumerate(self.feature_transformers):
-                X = self._collect_features(train_data, idx)
+                X = self._collect_features(train_data, idx)  # RAW
                 transformer.fit(X)
             for split in (train_data, val_data, test_data):
                 for idx, _ in enumerate(self.feature_transformers):
-                    self._apply_feature_transform(split, idx)
+                    self._apply_feature_transform(split, idx)  # from RAW
 
+        # 4) TARGETS: fit on RAW train from component 0; copy scaled y to all comps
         if self.target_transformers is not None:
-            Y = self._collect_targets(train_data)
-            for i, transformer in enumerate(self.target_transformers):
-                transformer.fit(Y[:, [i]])
+            self._fit_target_transformers(train_data)  # RAW
             for split in (train_data, val_data, test_data):
-                self._apply_target_transform(split)
+                self._apply_target_transform(split)  # from RAW
+
+        if self.atom_desc_scaler is not None:
+            train_flat = [comp for sample in train_data for comp in sample]
+            self.atom_desc_scaler.fit(train_flat)
+            for split in (train_data, val_data, test_data):
+                flat = [comp for sample in split for comp in sample]
+                self.atom_desc_scaler.transform(flat)
 
         return train_data, val_data, test_data
 
+    def _fit_target_transformers(self, train_data: List) -> None:
+        Y = self._collect_targets(train_data)
+        if self.n_targets_ is None:
+            self.n_targets_ = Y.shape[1]
+        assert self.n_targets_ == len(self.target_transformers)
+        assert Y.shape[1] == self.n_targets_
+        for i, t in enumerate(self.target_transformers):
+            if (
+                t.__class__.__name__ == "PowerTransformer"
+                and getattr(t, "method", "") == "box-cox"
+            ):
+                if not np.all(Y[:, i] > 0):
+                    bad = np.where(Y[:, i] <= 0)[0][:5]
+                    raise ValueError(
+                        f"Box–Cox column {i} has non-positive values at indices {bad.tolist()}"
+                    )
+            t.fit(Y[:, [i]])
+
     # Helpers ------------------------------------------------------------
     def _collect_features(self, data_list: List, comp_idx: int) -> np.ndarray:
-        feats = [sample[comp_idx].global_features.numpy() for sample in data_list]
+        feats = [sample[comp_idx].global_features_raw.numpy() for sample in data_list]
         return np.vstack(feats)
+
+    def _collect_extra_atom_features(
+        self, data_list: List, comp_idx: int
+    ) -> np.ndarray:
+        extras = [
+            d.f_atoms_raw[:, comp_idx].numpy()
+            for d in data_list
+            if hasattr(d, "f_atoms_raw")
+        ]
+        return np.vstack(extras) if len(extras) else np.zeros((0,))
+
+    def _collect_targets(self, data_list: List) -> np.ndarray:
+        targets = [sample[0].y_raw.numpy() for sample in data_list]
+        return np.vstack(targets)
+
+    def _apply_extra_atom_transformers(self, data_list: List) -> None:
+        if self.extra_atom_transformers is None:
+            return
+        for d in data_list:
+            for i, transformer in enumerate(self.extra_atom_transformers):
+                if not hasattr(d, "f_atoms_raw") or d.f_atoms_raw is None:
+                    continue
+                x = d.f_atoms_raw[:, i].numpy().reshape(1, -1)
+                transformed = transformer.transform(x)
+                d.f_atoms[:, i] = torch.tensor(transformed, dtype=torch.float32)
+
+    def _fit_extra_atom_transformers(self, train_data: List) -> None:
+        if self.extra_atom_transformers is None:
+            return
+        for i, transformer in enumerate(self.extra_atom_transformers):
+            X = self._collect_extra_atom_features(train_data, i)
+            if X.size:
+                transformer.fit(X)
 
     def _apply_feature_transform(self, data_list: List, comp_idx: int) -> None:
         transformer = self.feature_transformers[comp_idx]
         for sample in data_list:
-            arr = sample[comp_idx].global_features.numpy().reshape(1, -1)
+            comp = sample[comp_idx]
+            arr = comp.global_features_raw.numpy().reshape(1, -1)
             transformed = transformer.transform(arr)
-            sample[comp_idx].global_features = torch.tensor(
+            comp.global_features = torch.tensor(
                 transformed.squeeze(), dtype=torch.float32
             )
 
-    def _collect_targets(self, data_list: List) -> np.ndarray:
-        targets = [sample[0].y.numpy() for sample in data_list]
-        return np.vstack(targets)
-
     def _apply_target_transform(self, data_list: List) -> None:
         for sample in data_list:
-            y = sample[0].y.numpy().reshape(1, -1)
-            cols = [t.transform(y[:, [i]]) for i, t in enumerate(self.target_transformers)]
-            transformed = np.hstack(cols)
-            new_tensor = torch.tensor(transformed.squeeze(), dtype=torch.float32)
+            y = sample[0].y_raw.numpy().reshape(1, -1)
+            assert y.shape[1] == self.n_targets_
+            cols = [
+                t.transform(y[:, [i]]) for i, t in enumerate(self.target_transformers)
+            ]
+            transformed = np.hstack(cols).reshape(-1)
+            new_tensor = torch.tensor(transformed, dtype=torch.float32)
             for comp in sample:
                 comp.y = new_tensor.clone()
+
+    def _fit_extra_atom_transformers(self, train_data: List) -> None:
+        if self.extra_atom_transformers is None:
+            return
+        for i, transformer in enumerate(self.extra_atom_transformers):
+            X = self._collect_extra_atom_features(train_data, i)
+            if X.size:
+                transformer.fit(X)
+
+    def _fit_target_transformers(self, train_data: List) -> None:
+        Y = self._collect_targets(train_data)
+        if self.n_targets_ is None:
+            self.n_targets_ = Y.shape[1]
+        assert self.n_targets_ == len(self.target_transformers)
+        assert Y.shape[1] == self.n_targets_
+        for i, t in enumerate(self.target_transformers):
+            if (
+                t.__class__.__name__ == "PowerTransformer"
+                and getattr(t, "method", "") == "box-cox"
+            ):
+                if not np.all(Y[:, i] > 0):
+                    bad = np.where(Y[:, i] <= 0)[0][:5]
+                    raise ValueError(
+                        f"Box–Cox column {i} has non-positive values at indices {bad.tolist()}"
+                    )
+            t.fit(Y[:, [i]])
+
+    def build_target_unscaler(self):
+        return (
+            ColumnUnscaler(self.target_transformers)
+            if self.target_transformers
+            else None
+        )
+
+    def reset_to_raw(self, data_list: Optional[List] = None) -> None:
+        if data_list is None:
+            data_list = self.dataset
+        for sample in data_list:
+            for comp in sample:
+                if hasattr(comp, "y_raw"):
+                    comp.y = comp.y_raw.detach().clone()
+                if hasattr(comp, "global_features_raw"):
+                    comp.global_features = comp.global_features_raw.detach().clone()
+                if hasattr(comp, "f_atoms_raw"):
+                    comp.f_atoms = comp.f_atoms_raw.detach().clone()
+                if hasattr(comp, "f_bonds_raw"):
+                    comp.f_bonds = comp.f_bonds_raw.detach().clone()

--- a/cmpnn/models/arrhenius.py
+++ b/cmpnn/models/arrhenius.py
@@ -1,0 +1,81 @@
+import torch
+from torch import nn
+from typing import Iterable, Callable, List
+
+
+class ArrheniusLayer(nn.Module):
+    r"""Compute :math:`\ln k(T)` from Arrhenius parameters.
+
+    Parameters
+    ----------
+    temps:
+        Iterable of temperatures in Kelvin at which the rate constant should be
+        evaluated.
+    use_kJ:
+        Whether activation energies are provided in kJ/mol.  If ``False`` the
+        values are assumed to be in J/mol.
+    lnk_mean / lnk_scale:
+        Optional mean and standard deviation used to (de-)standardise
+        :math:`\ln k(T)`.  These are typically obtained from a
+        ``StandardScaler``.
+    """
+
+    def __init__(
+        self,
+        temps: Iterable[float],
+        *,
+        use_kJ: bool = True,
+        lnk_mean: torch.Tensor | None = None,
+        lnk_scale: torch.Tensor | None = None,
+    ) -> None:
+        super().__init__()
+
+        self.register_buffer("T", torch.tensor(list(temps), dtype=torch.float32))
+        self.R = 8.31446261815324e-3 if use_kJ else 8.31446261815324
+        self.register_buffer("T0", torch.tensor(1.0, dtype=torch.float32))
+
+        if lnk_mean is not None and lnk_scale is not None:
+            self.register_buffer("lnk_mu", lnk_mean.float())
+            self.register_buffer("lnk_sig", lnk_scale.float())
+        else:
+            self.lnk_mu = self.lnk_sig = None
+
+    def forward(
+        self, params: torch.Tensor, sampled_indices: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        r"""Evaluate :math:`\ln k` for a batch of Arrhenius parameters.
+
+        Parameters
+        ----------
+        params:
+            Tensor of shape ``(B, 3)`` with columns ``[A, n, Ea]``.  ``A`` is in
+            ``s⁻¹`` and ``Ea`` in ``kJ mol⁻¹`` (or ``J mol⁻¹`` when
+            ``use_kJ=False``).
+        sampled_indices:
+            Optional indices selecting which temperatures to use.  If ``None``
+            all temperatures passed at construction time are used.
+        """
+
+        A, n, Ea = params.unbind(1)
+
+        T = self.T if sampled_indices is None else self.T[sampled_indices]
+        T = T.to(A.device).unsqueeze(0)
+
+        ln_k = (
+            torch.log(torch.clamp(A, min=1e-30)).unsqueeze(1)
+            + n.unsqueeze(1) * torch.log(T / self.T0)
+            - Ea.unsqueeze(1) / (self.R * T)
+        )
+
+        if self.lnk_mu is not None:
+            mu = (
+                self.lnk_mu if sampled_indices is None else self.lnk_mu[sampled_indices]
+            )
+            sig = (
+                self.lnk_sig
+                if sampled_indices is None
+                else self.lnk_sig[sampled_indices]
+            )
+            ln_k = (ln_k - mu) / sig
+
+        return ln_k

--- a/cmpnn/scaler/atom_scaler.py
+++ b/cmpnn/scaler/atom_scaler.py
@@ -1,0 +1,104 @@
+# selective_atom_descriptor_scaler.py
+import numpy as np
+import torch
+from sklearn.preprocessing import StandardScaler  # or any sklearn scaler
+
+class AtomDescriptorScaler:
+    """
+    Scale only selected columns within the 'extra' descriptor slice of f_atoms.
+    Optionally mirror the (updated) atom features back into the atom-prefix of f_bonds.
+    If mirror_into_bonds is None, auto-detect by checking if f_bonds' prefix equals f_atoms[b2a].
+    """
+
+    def __init__(self, atom_base_dim, extra_dim,
+                 scale_idx=None,                  # <— indices relative to the extra slice
+                 scaler_cls=StandardScaler,
+                 mirror_into_bonds=None):
+        self.atom_base_dim = int(atom_base_dim)
+        self.extra_dim = int(extra_dim)
+        if scale_idx is None:
+            self.scale_idx = list(range(self.extra_dim))
+        else:
+            # dedupe, cast to int, keep only valid indices
+            idx = {int(i) for i in scale_idx if 0 <= int(i) < self.extra_dim}
+            if not idx and self.extra_dim > 0:
+                raise ValueError("scale_idx has no valid indices within [0, extra_dim).")
+            self.scale_idx = sorted(idx)
+        self.scalers = [scaler_cls() for _ in self.scale_idx]
+        self._mirror_flag = mirror_into_bonds  # None => auto-detect in fit
+        self.fitted = False
+
+    def _auto_detect_mirror(self, mol) -> bool:
+        A_raw = getattr(mol, "f_atoms_raw", getattr(mol, "f_atoms", None))
+        B_raw = getattr(mol, "f_bonds_raw", getattr(mol, "f_bonds", None))
+        b2a   = getattr(mol, "b2a", None)
+        if A_raw is None or B_raw is None or b2a is None:
+            return False
+        atom_dim = A_raw.shape[1]
+        if B_raw.shape[1] < atom_dim:
+            return False
+        src = torch.as_tensor(b2a, dtype=torch.long, device=A_raw.device)
+        return torch.allclose(B_raw[:, :atom_dim], A_raw.index_select(0, src))
+
+    def fit(self, mols):
+        # decide mirroring
+        if self._mirror_flag is None:
+            self._mirror_flag = any(self._auto_detect_mirror(m) for m in mols)
+
+        # nothing to scale
+        if self.extra_dim == 0 or len(self.scale_idx) == 0:
+            self.fitted = True
+            return
+
+        # gather per-column data from *_raw if present
+        base = self.atom_base_dim
+        cols_global = [base + i for i in self.scale_idx]
+        per_col = [[] for _ in self.scale_idx]
+
+        for m in mols:
+            A_raw = getattr(m, "f_atoms_raw", getattr(m, "f_atoms", None))
+            if A_raw is None:
+                continue
+            for j, c in enumerate(cols_global):
+                # keep as (n,1) to please sklearn
+                per_col[j].append(A_raw[:, c:c+1].detach().cpu().numpy())
+
+        # fit each scaler independently
+        for j, parts in enumerate(per_col):
+            if parts:
+                Xj = np.vstack(parts)  # (sum_atoms, 1)
+                self.scalers[j].fit(Xj)
+
+        self.fitted = True
+
+    @torch.no_grad()
+    def transform(self, mols):
+        assert self.fitted, "Call fit(...) before transform(...)."
+
+        base = self.atom_base_dim
+        cols_global = [base + i for i in self.scale_idx]
+
+        for m in mols:
+            A_raw = getattr(m, "f_atoms_raw", getattr(m, "f_atoms", None))
+            if A_raw is None:
+                continue
+
+            # start from RAW to stay idempotent
+            A = A_raw.clone()
+
+            # scale only the selected columns
+            for j, c in enumerate(cols_global):
+                col = A_raw[:, c:c+1].detach().cpu().numpy()       # (n,1)
+                col_t = self.scalers[j].transform(col)             # (n,1)
+                A[:, c:c+1] = torch.from_numpy(col_t).to(A.device, dtype=A.dtype)
+
+            # write back
+            m.f_atoms = A
+
+            # mirror into f_bonds atom-prefix only if we detected/forced mirroring
+            if self._mirror_flag:
+                B = getattr(m, "f_bonds", None)
+                b2a = getattr(m, "b2a", None)
+                if B is not None and b2a is not None and B.shape[1] >= A.shape[1]:
+                    src = torch.as_tensor(b2a, dtype=torch.long, device=A.device)
+                    B[:, :A.shape[1]] = A.index_select(0, src)

--- a/cmpnn/scaler/unscalers.py
+++ b/cmpnn/scaler/unscalers.py
@@ -1,0 +1,270 @@
+from typing import Optional, List
+import torch
+import torch.nn as nn
+import numpy as np
+
+try:
+    from sklearn.preprocessing import (
+        StandardScaler,
+        RobustScaler,
+        MinMaxScaler,
+        PowerTransformer,
+    )
+except ImportError:
+    StandardScaler = RobustScaler = MinMaxScaler = PowerTransformer = tuple()
+
+
+def _is_standard(t):
+    return (
+        (
+            (StandardScaler is not None and isinstance(t, StandardScaler))
+            or (t.__class__.__name__ == "StandardScaler")
+        )
+        and hasattr(t, "mean_")
+        and hasattr(t, "scale_")
+    )
+
+
+def _is_minmax(t):
+    return (
+        (
+            (MinMaxScaler is not None and isinstance(t, MinMaxScaler))
+            or (t.__class__.__name__ == "MinMaxScaler")
+        )
+        and hasattr(t, "data_min_")
+        and hasattr(t, "data_max_")
+        and hasattr(t, "feature_range")
+    )
+
+
+def _is_robust(t):
+    return (
+        (RobustScaler is not None and isinstance(t, RobustScaler))
+        or (t.__class__.__name__ == "RobustScaler")
+    ) and hasattr(t, "scale_")
+
+
+def _is_power(t):
+    return (
+        (PowerTransformer is not None and isinstance(t, PowerTransformer))
+        or (t.__class__.__name__ == "PowerTransformer")
+    ) and hasattr(t, "lambdas_")
+
+
+class _AffineColumnUnscaler(nn.Module):
+    """
+    Torch-native inverse for affine scalers: y = (y_scale - mean_) / scale_ (forward)
+    Inverse: y = y * scale_ + mean_
+    Handles per-column params as registered buffers so it checkpoints cleanly.
+    """
+
+    def __init__(
+        self, mean: Optional[torch.Tensor] = None, scale: Optional[torch.Tensor] = None
+    ):
+        super().__init__()
+        # mean/scale can be None for scalers that center or scale selectively; use zeros/ones
+        if mean is None:
+            mean = torch.zeros(1)
+        if scale is None:
+            scale = torch.ones(1)
+        self.register_buffer("mean", mean)  # [n_cols]
+        self.register_buffer("scale", scale)  # [n_cols]
+
+    def forward(self, y_scaled: torch.Tensor) -> torch.Tensor:
+        # y_scaled: [B, T]
+        if self.mean.numel() == 0 and self.scale.numel() == 0:
+            return y_scaled
+        return y_scaled * self.scale + self.mean
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(mean={self.mean}, scale={self.scale})"
+
+
+class ColumnUnscaler(nn.Module):
+    """
+    Wrap a list of sklearn-style transformers (one per target column).
+    For known affine scalers (Standard/MinMax/Robust) -> vectorized Torch path.
+    Otherwise -> safe NumPy fallback (CPU); still works during eval/metric logging.
+    """
+
+    def __init__(self, transformers):
+        super().__init__()
+        self.transformers = list(transformers)
+
+        a_list, b_list, aff_mask = [], [], []
+        pt_mask, pt_method, pt_lambda, pt_std, pt_mu, pt_sigma = [], [], [], [], [], []
+
+        for t in self.transformers:
+            if _is_standard(t):
+                a_list.append(float(np.ravel(t.scale_)[0]))
+                b_list.append(float(np.ravel(t.mean_)[0]))
+                aff_mask.append(True)
+                pt_mask.append(False)
+                pt_method.append("")
+                pt_lambda.append(0.0)
+                pt_std.append(False)
+                pt_mu.append(0.0)
+                pt_sigma.append(1.0)
+
+            elif _is_minmax(t):
+                dmin = float(np.ravel(t.data_min_)[0])
+                dmax = float(np.ravel(t.data_max_)[0])
+                fr_min, fr_max = t.feature_range
+                a = (dmax - dmin) / (fr_max - fr_min)
+                b = dmin - a * fr_min
+                a_list.append(a)
+                b_list.append(b)
+                aff_mask.append(True)
+                pt_mask.append(False)
+                pt_method.append("")
+                pt_lambda.append(0.0)
+                pt_std.append(False)
+                pt_mu.append(0.0)
+                pt_sigma.append(1.0)
+
+            elif _is_robust(t):
+                center = float(np.ravel(getattr(t, "center_", [0.0]))[0])
+                scale = float(np.ravel(getattr(t, "scale_", [1.0]))[0])
+                a_list.append(scale)
+                b_list.append(center)
+                aff_mask.append(True)
+                pt_mask.append(False)
+                pt_method.append("")
+                pt_lambda.append(0.0)
+                pt_std.append(False)
+                pt_mu.append(0.0)
+                pt_sigma.append(1.0)
+
+            elif _is_power(t):
+                a_list.append(1.0)
+                b_list.append(0.0)
+                aff_mask.append(False)
+                pt_mask.append(True)
+                pt_method.append(t.method)  # 'yeo-johnson' or 'box-cox'
+                pt_lambda.append(float(np.ravel(t.lambdas_)[0]))
+                stdize = bool(getattr(t, "standardize", True))
+                pt_std.append(stdize)
+                if stdize and hasattr(t, "_scaler"):
+                    pt_mu.append(float(np.ravel(t._scaler.mean_)[0]))
+                    pt_sigma.append(float(np.ravel(t._scaler.scale_)[0]))
+                else:
+                    pt_mu.append(0.0)
+                    pt_sigma.append(1.0)
+
+            else:
+                a_list.append(1.0)
+                b_list.append(0.0)
+                aff_mask.append(False)
+                pt_mask.append(False)
+                pt_method.append("")
+                pt_lambda.append(0.0)
+                pt_std.append(False)
+                pt_mu.append(0.0)
+                pt_sigma.append(1.0)
+
+        # buffers
+        self.register_buffer("aff_a", torch.tensor(a_list, dtype=torch.float32))
+        self.register_buffer("aff_b", torch.tensor(b_list, dtype=torch.float32))
+        self.register_buffer("aff_mask", torch.tensor(aff_mask, dtype=torch.bool))
+
+        self.pt_method = pt_method
+        self.register_buffer("pt_mask", torch.tensor(pt_mask, dtype=torch.bool))
+        self.register_buffer("pt_lambda", torch.tensor(pt_lambda, dtype=torch.float32))
+        self.register_buffer("pt_std", torch.tensor(pt_std, dtype=torch.bool))
+        self.register_buffer("pt_mu", torch.tensor(pt_mu, dtype=torch.float32))
+        self.register_buffer("pt_sigma", torch.tensor(pt_sigma, dtype=torch.float32))
+
+    @staticmethod
+    def _inv_box_cox(z: torch.Tensor, lam: torch.Tensor) -> torch.Tensor:
+        """Inverse Box-Cox transform."""
+        # z, lam broadcast on last dim
+        eps = 1e-12
+        out = torch.where(
+            torch.abs(lam) > 1e-12,
+            torch.pow(lam * z + 1.0, 1.0 / (lam + eps)),
+            torch.exp(z),
+        )
+        return out
+
+    @staticmethod
+    def _inv_yeo_johnson(z: torch.Tensor, lam: torch.Tensor) -> torch.Tensor:
+        """Inverse Yeo-Johnson transform.
+        Split by sign of original x; YJ forward def implies:
+        - for x >= 0: z = (x + 1) ** lam - 1 / lam if lam != 0; log(x + 1) if lam == 0
+        - for x < 0: z = -(1 - x) ** (2 - lam) / (2 - lam) if lam != 2; -log(1 - x) if lam == 2
+        Inverse requires choosing branch. The sign of original x corresponds to :
+        if z >= 0 -> x >= 0 branch; if z < 0 -> x < 0 branch (property of YJ).
+        """
+        eps = 1e-12
+        pos_branch = z >= 0
+        lam_ne0 = torch.abs(lam) > eps
+        lam_ne2 = torch.abs(lam - 2.0) > eps
+
+        x_pos = torch.where(
+            lam_ne0,
+            torch.pow(lam * z + 1.0, 1.0 / (lam + eps)) - 1.0,
+            torch.exp(z) - 1.0,
+        )
+        x_neg = torch.where(
+            lam_ne2,
+            1.0 - torch.pow(-(2.0 - lam) * z + 1.0, 1.0 / (2.0 - lam + eps)),
+            1.0 - torch.exp(-z),
+        )
+        return torch.where(pos_branch, x_pos, x_neg)
+
+    def forward(self, y_scaled: torch.Tensor) -> torch.Tensor:
+        y = y_scaled.clone()
+        dev = y.device
+        eps = 1e-12
+
+        # 1) Affine columns: x = a*z + b
+        if self.aff_mask.any():
+            m = self.aff_mask.to(dev)
+            y[:, m] = y[:, m] * self.aff_a[m].to(dev) + self.aff_b[m].to(dev)
+
+        # 2) PowerTransformer columns (destandardize -> inverse power)
+        if self.pt_mask.any():
+            cols = self.pt_mask.nonzero(as_tuple=False).view(-1).tolist()
+            for col in cols:
+                z = y[:, col]
+                if bool(self.pt_std[col].item()):
+                    z = z * self.pt_sigma[col].to(dev) + self.pt_mu[col].to(dev)
+                lam = self.pt_lambda[col].to(dev)
+
+                if self.pt_method[col] == "box-cox":
+                    x = torch.where(
+                        torch.abs(lam) > eps,
+                        torch.pow(lam * z + 1.0, 1.0 / (lam + eps)),
+                        torch.exp(z),
+                    )
+                else:  # yeo-johnson
+                    pos = z >= 0
+                    lam_ne0 = torch.abs(lam) > eps
+                    lam_ne2 = torch.abs(lam - 2.0) > eps
+                    x_pos = torch.where(
+                        lam_ne0,
+                        torch.pow(lam * z + 1.0, 1.0 / (lam + eps)) - 1.0,
+                        torch.exp(z) - 1.0,
+                    )
+                    x_neg = torch.where(
+                        lam_ne2,
+                        1.0
+                        - torch.pow(-(2.0 - lam) * z + 1.0, 1.0 / (2.0 - lam + eps)),
+                        1.0 - torch.exp(-z),
+                    )
+                    x = torch.where(pos, x_pos, x_neg)
+
+                y[:, col] = x
+
+        # 3) Fallback for any unknowns
+        remain = (~self.aff_mask) & (~self.pt_mask)
+        if remain.any():
+            cols = remain.nonzero(as_tuple=False).view(-1).tolist()
+            arr = y[:, cols].detach().cpu().numpy()
+            outs = [
+                self.transformers[c].inverse_transform(arr[:, [j]])
+                for j, c in enumerate(cols)
+            ]
+            y[:, cols] = torch.from_numpy(np.hstack(outs)).to(y.dtype).to(dev)
+
+        return y

--- a/setup_device_torch.sh
+++ b/setup_device_torch.sh
@@ -51,6 +51,10 @@ elif [[ $backend == "rocm" ]]; then
 	wget https://github.com/Looong01/pyg-rocm-build/releases/download/9/torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
 	unzip torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
 	pip install torch_*.whl
+	# Remove downloaded zip file
+	rm -v torch-2.6-rocm-6.2.4-py312-linux_x86_64.zip
+	# Remove the wheels
+	rm -v torch_*.whl
 
 else
 	echo "Invalid backend: choose one of [cpu, cuda, rocm]"

--- a/tests/integration/test_holder_atom_scaler.py
+++ b/tests/integration/test_holder_atom_scaler.py
@@ -1,0 +1,215 @@
+import numpy as np
+import torch
+import pytest
+
+from sklearn.preprocessing import StandardScaler
+
+from cmpnn.data.dataset_holder import MoleculeDatasetHolder, MultiMoleculeDatasetHolder
+from cmpnn.data.molecule_data import MoleculeData
+from cmpnn.scaler.atom_scaler import AtomDescriptorScaler
+
+
+# --- tiny helpers -------------------------------------------------------------
+class DummyMol(MoleculeData):
+    def __init__(self, f_atoms, f_bonds, b2a):
+        super().__init__()
+        self.f_atoms = torch.tensor(f_atoms, dtype=torch.float32)
+        self.f_bonds = torch.tensor(f_bonds, dtype=torch.float32)
+        self.b2a = torch.tensor(b2a, dtype=torch.long)
+        # also provide minimal globals/targets to keep holder paths happy
+        self.global_features = torch.zeros(2, dtype=torch.float32)
+        self.y = torch.zeros(1, dtype=torch.float32)
+
+class EchoSplitter:
+    """Return the same sequence for train/val/test (keeps indices & ordering)."""
+    def split(self, dataset, **_):
+        return dataset, list(dataset), list(dataset)
+
+class EchoSplitterMulti:
+    def split(self, dataset, **_):
+        return dataset, list(dataset), list(dataset)
+
+
+def _make_mols_with_mirroring(rng, atom_base=4, extra_dim=3, n_mols=5, nA_range=(3,6)):
+    mols = []
+    for _ in range(n_mols):
+        nA = rng.integers(*nA_range)
+        base = np.eye(atom_base, dtype=np.float32)[rng.integers(0, atom_base, size=nA)]
+        extras = rng.normal(loc=5.0, scale=2.0, size=(nA, extra_dim)).astype(np.float32)
+        f_atoms = np.hstack([base, extras])
+        atom_dim = f_atoms.shape[1]
+        b2a = np.arange(nA, dtype=np.int64)            # one bond per atom (simple mapping)
+        f_bonds = np.zeros((nA, atom_dim + 2), dtype=np.float32)  # +2 dummy bond feats
+        f_bonds[:, :atom_dim] = f_atoms[b2a]           # mirror atom features into bonds
+        mols.append(DummyMol(f_atoms, f_bonds, b2a))
+    return mols, atom_base, extra_dim
+
+def _make_mols_without_mirroring(rng, atom_base=4, extra_dim=2, n_mols=4, nA_range=(3,5)):
+    mols = []
+    for _ in range(n_mols):
+        nA = rng.integers(*nA_range)
+        base = np.eye(atom_base, dtype=np.float32)[rng.integers(0, atom_base, size=nA)]
+        extras = rng.normal(size=(nA, extra_dim)).astype(np.float32)
+        f_atoms = np.hstack([base, extras])
+        b2a = np.arange(nA, dtype=np.int64)
+        f_bonds = np.random.normal(size=(nA, 5)).astype(np.float32)  # no atom prefix here
+        mols.append(DummyMol(f_atoms, f_bonds, b2a))
+    return mols, atom_base, extra_dim
+
+
+
+def test_single_holder_atom_desc_scaling_with_mirroring_and_idempotency():
+    rng = np.random.default_rng(0)
+    dataset, atom_base, extra_dim = _make_mols_with_mirroring(rng, atom_base=4, extra_dim=3)
+
+    holder = MoleculeDatasetHolder(dataset)
+    splitter = EchoSplitter()
+
+    scaler = AtomDescriptorScaler(
+        atom_base_dim=atom_base,
+        extra_dim=extra_dim,
+        scaler_cls=StandardScaler,
+        mirror_into_bonds=None,  # auto-detect
+    )
+
+    train, val, test = holder.split(
+        splitter=splitter,
+        atom_desc_scaler=scaler,
+        feature_transformer=None,
+        target_transformers=None,
+    )
+
+    # 1) extras should be ~standardized across all atoms in train
+    cols = slice(atom_base, atom_base + extra_dim)
+    X = np.vstack([m.f_atoms[:, cols].numpy() for m in train])
+    assert np.allclose(X.mean(axis=0), 0.0, atol=0.15)
+    assert np.all((X.std(axis=0) > 0.8) & (X.std(axis=0) < 1.2))
+
+    # 2) bonds should mirror atom features after scaling
+    for m in train:
+        A, B = m.f_atoms, m.f_bonds
+        atom_dim = A.shape[1]
+        assert torch.allclose(B[:, :atom_dim], A.index_select(0, m.b2a))
+
+    # 3) idempotency: calling transform again should not double-scale
+    snap = [m.f_atoms.clone() for m in train]
+    scaler.transform(train)
+    for a, m in zip(snap, train):
+        assert torch.allclose(a, m.f_atoms, atol=1e-7)
+
+
+def test_single_holder_atom_desc_scaling_without_mirroring():
+    rng = np.random.default_rng(1)
+    dataset, atom_base, extra_dim = _make_mols_without_mirroring(rng, atom_base=3, extra_dim=2)
+
+    holder = MoleculeDatasetHolder(dataset)
+    splitter = EchoSplitter()
+
+    scaler = AtomDescriptorScaler(
+        atom_base_dim=atom_base,
+        extra_dim=extra_dim,
+        scaler_cls=StandardScaler,
+        mirror_into_bonds=None,  # auto-detect -> should be False here
+    )
+
+    train, _, _ = holder.split(
+        splitter=splitter,
+        atom_desc_scaler=scaler,
+        feature_transformer=None,
+        target_transformers=None,
+    )
+
+    # extras standardized
+    cols = slice(atom_base, atom_base + extra_dim)
+    X = np.vstack([m.f_atoms[:, cols].numpy() for m in train])
+    assert np.allclose(X.mean(axis=0), 0.0, atol=0.15)
+
+    # bonds NOT mirrored (prefix shouldn't equal atom features)
+    for m in train:
+        A, B = m.f_atoms, m.f_bonds
+        atom_dim = A.shape[1]
+        # if shapes mismatch, we're definitely not mirroring
+        if B.shape[1] < atom_dim:
+            continue
+        assert not torch.allclose(B[:, :atom_dim], A.index_select(0, m.b2a))
+
+
+def test_single_holder_atom_desc_selective_scaling():
+    """Scale only a subset of extra columns (e.g., last 2 of 5 extras)."""
+    rng = np.random.default_rng(2)
+    dataset, atom_base, extra_dim = _make_mols_with_mirroring(rng, atom_base=5, extra_dim=5)
+
+    # choose to scale only indices [2,3,4] within the extra block
+    scale_idx = [2, 3, 4]
+
+    holder = MoleculeDatasetHolder(dataset)
+    splitter = EchoSplitter()
+
+    scaler = AtomDescriptorScaler(
+        atom_base_dim=atom_base,
+        extra_dim=extra_dim,
+        scaler_cls=StandardScaler,
+        mirror_into_bonds=None,
+        scale_idx=scale_idx,     # requires your scaler to support scale_idx
+    )
+
+    # keep a raw copy for later comparison
+    raw_extras = [m.f_atoms[:, atom_base:].clone() for m in dataset]
+
+    train, _, _ = holder.split(
+        splitter=splitter,
+        atom_desc_scaler=scaler,
+        feature_transformer=None,
+        target_transformers=None,
+    )
+
+    # columns 0..1 in the extra block should be unchanged vs raw; 2..4 standardized
+    for m, raw in zip(train, raw_extras):
+        after = m.f_atoms[:, atom_base:]
+        # unchanged columns
+        assert torch.allclose(after[:, :2], raw[:, :2], atol=1e-7)
+        # scaled columns ~ zero mean across train atoms
+    X_scaled = np.vstack([m.f_atoms[:, atom_base+2:atom_base+5].numpy() for m in train])
+    assert np.allclose(X_scaled.mean(axis=0), 0.0, atol=0.2)
+
+
+def test_multi_holder_atom_desc_scaling_components_sync():
+    """MultiMoleculeDatasetHolder: components should share the same scaled atom extras."""
+    rng = np.random.default_rng(3)
+
+    # build paired molecules with the *same* raw features so we can compare directly
+    a_list, atom_base, extra_dim = _make_mols_with_mirroring(rng, atom_base=4, extra_dim=3, n_mols=6)
+    b_list, _, _ = _make_mols_with_mirroring(rng, atom_base=4, extra_dim=3, n_mols=6)
+
+    # make the second component have identical raw as the first to simplify equality checks
+    for a, b in zip(a_list, b_list):
+        b.f_atoms = a.f_atoms.clone()
+        b.f_bonds = a.f_bonds.clone()
+        b.b2a     = a.b2a.clone()
+
+    dataset = [[a, b] for a, b in zip(a_list, b_list)]
+    holder = MultiMoleculeDatasetHolder(dataset)
+    splitter = EchoSplitterMulti()
+
+    scaler = AtomDescriptorScaler(
+        atom_base_dim=atom_base,
+        extra_dim=extra_dim,
+        scaler_cls=StandardScaler,
+        mirror_into_bonds=None,
+    )
+
+    train, _, _ = holder.split(
+        splitter=splitter,
+        atom_desc_scaler=scaler,
+        feature_transformers=None,
+        target_transformers=None,
+    )
+
+    # components have identical scaled atoms and mirrored bonds
+    for pair in train:
+        A1, A2 = pair[0].f_atoms, pair[1].f_atoms
+        B1, B2 = pair[0].f_bonds, pair[1].f_bonds
+        assert torch.allclose(A1, A2, atol=1e-7)
+        atom_dim = A1.shape[1]
+        assert torch.allclose(B1[:, :atom_dim], A1.index_select(0, pair[0].b2a))
+        assert torch.allclose(B2[:, :atom_dim], A2.index_select(0, pair[1].b2a))

--- a/tests/integration/test_holder_unscaler_integration.py
+++ b/tests/integration/test_holder_unscaler_integration.py
@@ -1,0 +1,122 @@
+import numpy as np
+import torch
+import pytest
+from sklearn.preprocessing import PowerTransformer, StandardScaler
+
+from cmpnn.scaler.unscalers import ColumnUnscaler
+from cmpnn.data.dataset_holder import MoleculeDatasetHolder, MultiMoleculeDatasetHolder
+
+
+class DummyMol:
+    def __init__(self, glob_feats, y):
+        self.glob_feats = torch.tensor(glob_feats, dtype=torch.float32)
+        self.y = torch.tensor(y, dtype=torch.float32)
+
+
+class EchoSplitter:
+    """Returns the same sequence for train/val/test to keep ordering simple"""
+
+    def split(self, dataset, **_):
+        """
+        Split the dataset into train, validation, and test sets.
+
+        Parameters:
+            dataset: The dataset to split.
+            **_: Additional keyword arguments.
+
+        Returns:
+            A tuple containing the train, validation, and test sets.
+        """
+        return dataset, list(dataset), list(dataset)
+
+
+class EchoSplitterMulti:
+    """Returns the same sequence for train/val/test to keep ordering simple"""
+
+    def split(self, dataset, **_):
+        """
+        Split the dataset into train, validation, and test sets.
+
+        Parameters:
+            dataset: The dataset to split.
+            **_: Additional keyword arguments.
+
+        Returns:
+            A tuple containing the train, validation, and test sets.
+        """
+        return dataset, list(dataset), list(dataset)
+
+
+# Single Component Holder Test
+def test_molecule_holder_with_power_and_standard_inverse_matches_raw():
+    rng = np.random.default_rng(0)
+    Y_raw = np.hstack(
+        [
+            rng.normal(size=(64, 1)),  # YJ
+            rng.normal(loc=5.0, scale=2, size=(64, 1)),  # StandrdScaler
+        ]
+    ).astype(np.float64)
+
+    data = [DummyMol(glob_feats=[0.0, 1.0], y=Y_raw[i]) for i in range(len(Y_raw))]
+
+    holder = MoleculeDatasetHolder(data)
+    splitter = EchoSplitter()
+
+    tfs = [
+        PowerTransformer(method="yeo-johnson", standardize=True),
+        StandardScaler(),
+    ]
+
+    train, val, test = holder.split(splitter=splitter, target_transformers=tfs)
+
+    Y_scaled = np.stack([np.atleast_1d(d.y.numpy()) for d in train], axis=0)
+
+    un = ColumnUnscaler(holder.target_transformers)
+    Y_back = un(torch.tensor(Y_scaled, dtype=torch.float32)).numpy()
+
+    np.testing.assert_allclose(Y_back, Y_raw, rtol=1e-5, atol=1e-6)
+
+
+# Multi Component Holder Test
+def test_multi_holder_target_unscaler_and_component_sync():
+    """
+    Three target cols: col0 YJ, col1 BC, col2 StdScaler
+    """
+    rng = np.random.default_rng(42)
+    y0 = rng.normal(size=(48, 1))  # YJ
+    y1 = rng.lognormal(mean=0.0, sigma=0.6, size=(48, 1))  # Box–Cox (>0)
+    y2 = rng.normal(loc=5.0, scale=2.0, size=(48, 1))  # Standard
+    Y_raw = np.hstack([y0, y1, y2]).astype(np.float64)
+
+    donor = [DummyMol(glob_feats=[0.0, 1.0], y=Y_raw[i]) for i in range(len(Y_raw))]
+    acceptor = [DummyMol(glob_feats=[0.0, 1.0], y=Y_raw[i]) for i in range(len(Y_raw))]
+    multi_dataset = [[d, a] for d, a in zip(donor, acceptor)]
+
+    holder = MultiMoleculeDatasetHolder(multi_dataset)
+    splitter = EchoSplitterMulti()
+
+    tfs = [
+        PowerTransformer(method="yeo-johnson", standardize=True),
+        PowerTransformer(method="box-cox", standardize=True),
+        StandardScaler(),
+    ]
+
+    train, val, test = holder.split(splitter=splitter, target_transformers=tfs)
+
+    # both components should carry the same scaled y
+    for sample in train:
+        assert torch.allclose(sample[0].y, sample[1].y)
+
+    Y_scaled = np.vstack([sample[0].y.numpy() for sample in train])
+    un = ColumnUnscaler(holder.target_transformers)
+    # Expect YJ then StdScaler
+    assert un.aff_mask.tolist() == [
+        False,
+        False,
+        True,
+    ], f"aff_mask={un.aff_mask.tolist()}"
+    assert un.pt_mask.tolist() == [True, True, False], f"pt_mask={un.pt_mask.tolist()}"
+
+    Y_back = un(torch.tensor(Y_scaled, dtype=torch.float32)).numpy()
+
+    np.testing.assert_allclose(Y_back, Y_raw, rtol=1e-5, atol=1e-6)

--- a/tests/models/test_arrhenius.py
+++ b/tests/models/test_arrhenius.py
@@ -1,0 +1,27 @@
+import torch
+from cmpnn.models.arrhenius import ArrheniusLayer
+
+
+def test_arrhenius_basic():
+    temps = [300.0, 400.0]
+    layer = ArrheniusLayer(temps)
+    params = torch.tensor([[1.0e12, 0.5, 50.0]])  # A, n, Ea
+    out = layer(params)
+    R = 8.31446261815324e-3
+    T = torch.tensor(temps)
+    expected = torch.log(torch.tensor(1.0e12)) + 0.5 * torch.log(T) - 50.0 / (R * T)
+    assert torch.allclose(out.squeeze(0), expected, atol=1e-5)
+
+
+def test_arrhenius_standardised():
+    temps = [300.0, 400.0]
+    mean = torch.tensor([1.0, 2.0])
+    scale = torch.tensor([2.0, 4.0])
+    layer = ArrheniusLayer(temps, lnk_mean=mean, lnk_scale=scale)
+    params = torch.tensor([[1.0e12, 0.0, 0.0]])
+    raw = layer(params)
+    # Without standardisation the values are:
+    base_layer = ArrheniusLayer(temps)
+    base = base_layer(params)
+    expected = (base - mean) / scale
+    assert torch.allclose(raw, expected, atol=1e-5)

--- a/tests/scaler/test_atom_scaler.py
+++ b/tests/scaler/test_atom_scaler.py
@@ -1,0 +1,156 @@
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+import torch
+from cmpnn.scaler.atom_scaler import AtomDescriptorScaler
+
+
+class DummyMol:
+    def __init__(self, f_atoms, f_bonds, b2a):
+        self.f_atoms = torch.tensor(f_atoms, dtype=torch.float32)
+        self.f_bonds = torch.tensor(f_bonds, dtype=torch.float32)
+        self.b2a = torch.tensor(b2a, dtype=torch.long)
+        self.y = torch.tensor([0.0], dtype=torch.float32)
+        self.global_features = torch.tensor([0.0], dtype=torch.float32)
+
+
+def _ensure_raw(m):
+    if not hasattr(m, "f_atoms_raw"):
+        m.f_atoms_raw = m.f_atoms.clone()
+    if not hasattr(m, "f_bonds_raw"):
+        m.f_bonds_raw = m.f_bonds.clone()
+
+
+def test_atom_extras_scaling_and_mirroring():
+    rng = np.random.default_rng(0)
+    atom_base = 3
+    extra_dim = 2
+
+    mols = []
+    for _ in range(4):
+        nA = rng.integers(3, 6)
+        based = np.eye(atom_base, dtype=np.float32)[rng.integers(0, atom_base, size=nA)]
+        extras = rng.normal(5.0, 2.0, size=(nA, extra_dim)).astype(np.float32)
+        f_atoms = np.hstack([based, extras])
+        atom_dim = f_atoms.shape[1]
+        b2a = np.arange(nA, dtype=np.int64)
+        f_bonds = np.zeros(
+            (nA, atom_dim + 3), dtype=np.float32
+        )  # 3 dummy bond features
+        f_bonds[:, :atom_dim] = f_atoms[b2a]  # mirror atom features into bonds
+        mols.append(DummyMol(f_atoms, f_bonds, b2a))
+
+    for m in mols:
+        _ensure_raw(m)
+    scaler = AtomDescriptorScaler(
+        atom_base_dim=atom_base,
+        extra_dim=extra_dim,
+        scaler_cls=StandardScaler,
+        mirror_into_bonds=None,
+    )
+
+    scaler.fit(mols)
+    scaler.transform(mols)
+
+    # extra ~ standardised
+    cols = slice(atom_base, atom_base + extra_dim)
+    X = np.vstack([m.f_atoms[:, cols].numpy() for m in mols])
+    assert np.allclose(X.mean(0), 0.0, atol=0.15)
+    assert np.all((X.std(0) > 0.8) & (X.std(0) < 1.2))
+
+    # bonds mirrored
+    for m in mols:
+        A = m.f_atoms
+        B = m.f_bonds
+        atom_fdim = A.shape[1]
+        assert torch.allclose(B[:, :atom_fdim], A.index_select(0, m.b2a), atol=1e-6)
+
+    # idempotent (transform again does not double-scale)
+    before_atoms = [m.f_atoms.clone() for m in mols]
+    scaler.transform(mols)
+    after_atoms  = [m.f_atoms.clone() for m in mols]
+
+    for b, a in zip(before_atoms, after_atoms):
+        assert torch.allclose(b, a)
+
+
+def test_no_mirroring_when_no_prefix():
+    rng = np.random.default_rng(1)
+    atom_base, extra_dim = 2, 1
+
+    mols = []
+    for _ in range(3):
+        nA = rng.integers(3, 5)
+        base = np.eye(atom_base, dtype=np.float32)[rng.integers(0, atom_base, size=nA)]
+        extras = rng.normal(size=(nA, extra_dim)).astype(np.float32)
+        f_atoms = np.hstack([base, extras])
+        b2a = np.arange(nA, dtype=np.int64)
+        f_bonds = rng.normal(size=(nA, 5)).astype(np.float32)  # no atom prefix
+        mols.append(DummyMol(f_atoms, f_bonds, b2a))
+
+    for m in mols:
+        _ensure_raw(m)
+
+    # keep copies per molecule (shapes differ)
+    B_before = [m.f_bonds.clone() for m in mols]
+
+    scaler = AtomDescriptorScaler(atom_base_dim=atom_base, extra_dim=extra_dim,
+                                scaler_cls=StandardScaler, mirror_into_bonds=None)
+    scaler.fit(mols)
+    scaler.transform(mols)
+
+    B_after = [m.f_bonds.clone() for m in mols]
+    for Bb, Ba in zip(B_before, B_after):
+        assert torch.allclose(Bb, Ba)
+
+
+def test_selective_scaling_ohe_untouched():
+    rng = np.random.default_rng(0)
+    base_dim, extra_dim = 10, 5
+    scale_idx = [2,3,4]  # only last 3 extra cols
+    class M:
+        pass
+
+    mols = []
+    for _ in range(3):
+        nA = rng.integers(4, 7)
+        # base OHE (10 classes)
+        base = np.eye(base_dim, dtype=np.float32)[rng.integers(0, base_dim, size=nA)]
+        # extra: 2 OHE-like, 3 continuous
+        extra_ohe = np.eye(2, dtype=np.float32)[rng.integers(0, 2, size=nA)]
+        extra_cont = rng.normal(5.0, 2.0, size=(nA, 3)).astype(np.float32)
+        f_atoms = np.hstack([base, extra_ohe, extra_cont])
+
+        atom_dim = f_atoms.shape[1]
+        b2a = np.arange(nA, dtype=np.int64)
+        f_bonds = np.zeros((nA, atom_dim + 2), dtype=np.float32)
+        f_bonds[:, :atom_dim] = f_atoms[b2a]
+
+        m = M()
+        m.f_atoms = torch.tensor(f_atoms)
+        m.f_bonds = torch.tensor(f_bonds)
+        m.b2a = torch.tensor(b2a)
+        # raw snapshots
+        m.f_atoms_raw = m.f_atoms.clone()
+        m.f_bonds_raw = m.f_bonds.clone()
+        mols.append(m)
+
+    scaler = AtomDescriptorScaler(base_dim, extra_dim, scale_idx=scale_idx)
+    scaler.fit(mols)
+    scaler.transform(mols)
+
+    # base and first 2 extras unchanged
+    for m in mols:
+        assert torch.allclose(m.f_atoms[:, :base_dim+2], m.f_atoms_raw[:, :base_dim+2])
+
+    # last 3 extras roughly standardized
+    cols = slice(base_dim+2, base_dim+5)
+    X = np.vstack([m.f_atoms[:, cols].numpy() for m in mols])
+    assert np.allclose(X.mean(0), 0.0, atol=0.2)
+    assert np.all((X.std(0) > 0.8) & (X.std(0) < 1.2))
+
+    # mirrored into bonds
+    for m in mols:
+        A = m.f_atoms
+        B = m.f_bonds
+        atom_dim = A.shape[1]
+        assert torch.allclose(B[:, :atom_dim], A.index_select(0, m.b2a))

--- a/tests/scaler/test_unscaler.py
+++ b/tests/scaler/test_unscaler.py
@@ -1,0 +1,149 @@
+import numpy as np
+import torch
+import pytest
+
+from sklearn.preprocessing import (
+    PowerTransformer,
+    StandardScaler,
+    MinMaxScaler,
+    RobustScaler,
+)
+
+from cmpnn.scaler.unscalers import ColumnUnscaler
+
+
+def _rng_data(n=3000, seed=0):
+    """
+    Returns a matrix with 4 columns:
+    - col1: real-valued (Yeo–Johnson ok)
+    - col2: strictly positive (Box–Cox ok)
+    - col3: strictly positive (for other transforms)
+    - col4: heavy-tailed (to test robustness)
+    """
+    rng = np.random.default_rng(seed)
+    col1 = rng.normal(size=(n, 1))
+    col2 = rng.lognormal(mean=0.0, sigma=0.6, size=(n, 1))
+    col3 = np.clip(rng.normal(loc=3.0, scale=1.0, size=(n, 1)), 1e-3, None)
+    col4 = rng.standard_t(df=3, size=(n, 1))
+    return np.hstack([col1, col2, col3, col4]).astype(np.float64)
+
+
+@pytest.mark.parametrize("standardize", [True, False])
+def test_powertransformer_inverse_matches_sklearn(standardize):
+    """
+    Check that ColumnwiseUnscaler reproduces sklearn's inverse for:
+    - Yeo–Johnson on col1
+    - Box-Cox on col2
+    """
+    Y = _rng_data()
+    pt_yj = PowerTransformer(method="yeo-johnson", standardize=standardize).fit(
+        Y[:, [0]]
+    )
+
+    pt_bc = PowerTransformer(method="box-cox", standardize=standardize).fit(Y[:, [1]])
+
+    Yt = np.hstack([pt_yj.transform(Y[:, [0]]), pt_bc.transform(Y[:, [1]])])
+
+    un = ColumnUnscaler([pt_yj, pt_bc])
+
+    Y_back = un(torch.from_numpy(Yt).float()).cpu().numpy()
+
+    np.testing.assert_allclose(Y_back, Y[:, [0, 1]], rtol=1e-5, atol=1e-6)
+
+
+def test_mixed_transformers_roundtrip():
+    """
+    Mix affine torch-native paths and PowerTransformers.
+    """
+    Y = _rng_data()
+    tfs = [
+        StandardScaler().fit(Y[:, [0]]),
+        MinMaxScaler().fit(Y[:, [1]]),
+        RobustScaler().fit(Y[:, [2]]),
+        PowerTransformer(method="yeo-johnson", standardize=True).fit(Y[:, [3]]),
+    ]
+    Yt = np.hstack([t.transform(Y[:, [i]]) for i, t in enumerate(tfs)])
+
+    un = ColumnUnscaler(tfs)
+    Y_back = un(torch.from_numpy(Yt).float()).cpu().numpy()
+
+    np.testing.assert_allclose(Y_back, Y[:, :4], rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("method", ["yeo-johnson", "box-cox"])
+@pytest.mark.parametrize("standardize", [True, False])
+def test_powertransformer_multi_column(method, standardize):
+    """
+    Fit one PowerTransformer per column on a 3-col matrix
+    and verify the module handles per-column λ and std flags.
+    """
+    Y = _rng_data()[:, :3]
+    # Ensure positivity if Box–Cox across all cols
+    if method == "box-cox":
+        Y = np.clip(Y, 1e-3, None)
+
+    tfs = [
+        PowerTransformer(method=method, standardize=standardize).fit(Y[:, [i]])
+        for i in range(Y.shape[1])
+    ]
+    Yt = np.hstack([t.transform(Y[:, [i]]) for i, t in enumerate(tfs)])
+
+    un = ColumnUnscaler(tfs)
+    Y_back = un(torch.from_numpy(Yt).float()).cpu().numpy()
+
+    np.testing.assert_allclose(Y_back, Y, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_device_behavior(device):
+    """
+    The unscaler should accept inputs on CPU or CUDA and
+    emit outputs on the same device.
+    """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available on this runner.")
+
+    Y = _rng_data()[:, :2]
+    pt_yj = PowerTransformer(method="yeo-johnson", standardize=True).fit(Y[:, [0]])
+    pt_bc = PowerTransformer(method="box-cox", standardize=True).fit(
+        np.clip(Y[:, [1]], 1e-3, None)
+    )
+
+    Yt = np.hstack([pt_yj.transform(Y[:, [0]]), pt_bc.transform(Y[:, [1]])])
+
+    un = ColumnUnscaler([pt_yj, pt_bc]).to(device)
+    Yt_t = torch.from_numpy(Yt).float().to(device)
+    out = un(Yt_t)
+
+    assert out.device.type == device
+    np.testing.assert_allclose(
+        out.detach().cpu().numpy(), Y[:, :2], rtol=1e-5, atol=1e-6
+    )
+
+
+def test_state_dict_roundtrip(tmp_path):
+    """
+    Check that buffers (means, scales, λ, μ, σ, masks) survive save/load,
+    and outputs remain identical.
+    """
+    Y = _rng_data()[:, :2]
+    pt_yj = PowerTransformer(method="yeo-johnson", standardize=True).fit(Y[:, [0]])
+    pt_bc = PowerTransformer(method="box-cox", standardize=True).fit(
+        np.clip(Y[:, [1]], 1e-3, None)
+    )
+    tfs = [pt_yj, pt_bc]
+    Yt = np.hstack([t.transform(Y[:, [i]]) for i, t in enumerate(tfs)])
+    Yt_t = torch.from_numpy(Yt).float()
+
+    un1 = ColumnUnscaler(tfs)
+    out1 = un1(Yt_t).detach().cpu().numpy()
+
+    p = tmp_path / "un.pt"
+    torch.save(un1.state_dict(), p)
+
+    # Rebuild with same structure (methods/standardize flags) then load
+    un2 = ColumnUnscaler(tfs)
+    un2.load_state_dict(torch.load(p, map_location="cpu", weights_only=True))
+
+    out2 = un2(Yt_t).detach().cpu().numpy()
+    np.testing.assert_allclose(out2, out1, rtol=0, atol=0)


### PR DESCRIPTION
- Introduced AtomDescriptorScaler for selective scaling of atom features in molecular datasets.
- Implemented ColumnUnscaler to reverse transformations applied by various sklearn scalers.
- Added integration tests for AtomDescriptorScaler and ColumnUnscaler to ensure functionality and correctness.
- Created unit tests for atom scaling and unscaling, including scenarios for mirroring and selective scaling.
- Updated setup script to clean up downloaded files after installation.
- Added ArrheniusLayer model with basic tests for functionality.